### PR TITLE
Added initial nRF5340 I2C driver and cleanup

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/TARGET_NRF5340_DK/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/TARGET_NRF5340_DK/PinNames.h
@@ -204,8 +204,8 @@ typedef enum {
     SPIS_PSELSS   = P1_1,
     SPIS_PSELSCK  = P1_4,
 
-    I2C_SDA0 = p26,
-    I2C_SCL0 = p27,
+    I2C_SDA0 = P1_14,
+    I2C_SCL0 = P1_15,
 
     D0 = P1_1,
     D1 = P1_2,

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_CONFIG_H__
+#define NRFX_CONFIG_H__
+
+#if defined(NRF51)
+    #include <nrfx_config_nrf51.h>
+#elif defined(NRF52805_XXAA)
+    #include <nrfx_config_nrf52805.h>
+#elif defined(NRF52810_XXAA)
+    #include <nrfx_config_nrf52810.h>
+#elif defined(NRF52811_XXAA)
+    #include <nrfx_config_nrf52811.h>
+#elif defined(NRF52820_XXAA)
+    #include <nrfx_config_nrf52820.h>
+#elif defined(NRF52832_XXAA) || defined (NRF52832_XXAB)
+    #include <nrfx_config_nrf52832.h>
+#elif defined(NRF52833_XXAA)
+    #include <nrfx_config_nrf52833.h>
+#elif defined(NRF52840_XXAA)
+    #include <nrfx_config_nrf52840.h>
+#elif defined(NRF5340_XXAA_APPLICATION)
+    #include <nrfx_config_nrf5340_application.h>
+#elif defined(NRF5340_XXAA_NETWORK)
+    #include <nrfx_config_nrf5340_network.h>
+#elif defined(NRF9160_XXAA)
+    #include <nrfx_config_nrf9160.h>
+#else
+    #error "Unknown device."
+#endif
+
+#endif // NRFX_CONFIG_H__

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config_nrf5340_application.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config_nrf5340_application.h
@@ -1,0 +1,2169 @@
+/*
+ * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFX_CONFIG_NRF5340_APPLICATION_H__
+#define NRFX_CONFIG_NRF5340_APPLICATION_H__
+
+#ifndef NRFX_CONFIG_H__
+#error "This file should not be included directly. Include nrfx_config.h instead."
+#endif
+
+/*
+ * The MDK provides macros for accessing the peripheral register structures
+ * by using their secure and non-secure address mappings (with the names
+ * containing the suffix _S or _NS, respectively). Because the nrfx drivers
+ * use the macros without any suffixes, you must translate the names.
+ * The following section provides configuration for the name translation.
+ * It must be modified to reflect the actual configuration set in NRF_SPU.
+ */
+#define NRF_CLOCK        NRF_CLOCK_S
+#define NRF_COMP         NRF_COMP_S
+#define NRF_DCNF         NRF_DCNF_S
+#define NRF_DPPIC        NRF_DPPIC_S
+#define NRF_EGU0         NRF_EGU0_S
+#define NRF_EGU1         NRF_EGU1_S
+#define NRF_EGU2         NRF_EGU2_S
+#define NRF_EGU3         NRF_EGU3_S
+#define NRF_EGU4         NRF_EGU4_S
+#define NRF_EGU5         NRF_EGU5_S
+#define NRF_FPU          NRF_FPU_S
+#define NRF_I2S0         NRF_I2S0_S
+#define NRF_IPC          NRF_IPC_S
+#define NRF_KMU          NRF_KMU_S
+#define NRF_LPCOMP       NRF_LPCOMP_S
+#define NRF_MUTEX        NRF_MUTEX_S
+#define NRF_NFCT         NRF_NFCT_S
+#define NRF_NVMC         NRF_NVMC_S
+#define NRF_OSCILLATORS  NRF_OSCILLATORS_S
+#define NRF_P0           NRF_P0_S
+#define NRF_P1           NRF_P1_S
+#define NRF_PDM0         NRF_PDM0_S
+#define NRF_POWER        NRF_POWER_S
+#define NRF_PWM0         NRF_PWM0_S
+#define NRF_PWM1         NRF_PWM1_S
+#define NRF_PWM2         NRF_PWM2_S
+#define NRF_PWM3         NRF_PWM3_S
+#define NRF_QDEC0        NRF_QDEC0_S
+#define NRF_QDEC1        NRF_QDEC1_S
+#define NRF_QSPI         NRF_QSPI_S
+#define NRF_REGULATORS   NRF_REGULATORS_S
+#define NRF_RESET        NRF_RESET_S
+#define NRF_RTC0         NRF_RTC0_S
+#define NRF_RTC1         NRF_RTC1_S
+#define NRF_SAADC        NRF_SAADC_S
+#define NRF_SPIM0        NRF_SPIM0_S
+#define NRF_SPIM1        NRF_SPIM1_S
+#define NRF_SPIM2        NRF_SPIM2_S
+#define NRF_SPIM3        NRF_SPIM3_S
+#define NRF_SPIM4        NRF_SPIM4_S
+#define NRF_SPIS0        NRF_SPIS0_S
+#define NRF_SPIS1        NRF_SPIS1_S
+#define NRF_SPIS2        NRF_SPIS2_S
+#define NRF_SPIS3        NRF_SPIS3_S
+#define NRF_TIMER0       NRF_TIMER0_S
+#define NRF_TIMER1       NRF_TIMER1_S
+#define NRF_TIMER2       NRF_TIMER2_S
+#define NRF_TWIM0        NRF_TWIM0_S
+#define NRF_TWIM1        NRF_TWIM1_S
+#define NRF_TWIM2        NRF_TWIM2_S
+#define NRF_TWIM3        NRF_TWIM3_S
+#define NRF_TWIS0        NRF_TWIS0_S
+#define NRF_TWIS1        NRF_TWIS1_S
+#define NRF_TWIS2        NRF_TWIS2_S
+#define NRF_TWIS3        NRF_TWIS3_S
+#define NRF_UARTE0       NRF_UARTE0_S
+#define NRF_UARTE1       NRF_UARTE1_S
+#define NRF_UARTE2       NRF_UARTE2_S
+#define NRF_UARTE3       NRF_UARTE3_S
+#define NRF_USBD         NRF_USBD_S
+#define NRF_USBREGULATOR NRF_USBREGULATOR_S
+#define NRF_VMC          NRF_VMC_S
+#define NRF_WDT0         NRF_WDT0_S
+#define NRF_WDT1         NRF_WDT1_S
+
+/*
+ * The following section provides the name translation for peripherals with
+ * only one type of access available. For these peripherals, you cannot choose
+ * between secure and non-secure mapping.
+ */
+#if defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_GPIOTE1      NRF_GPIOTE1_NS
+#else
+#define NRF_CACHE        NRF_CACHE_S
+#define NRF_CACHEINFO    NRF_CACHEINFO_S
+#define NRF_CACHEDATA    NRF_CACHEDATA_S
+#define NRF_CRYPTOCELL   NRF_CRYPTOCELL_S
+#define NRF_CTI          NRF_CTI_S
+#define NRF_FICR         NRF_FICR_S
+#define NRF_GPIOTE0      NRF_GPIOTE0_S
+#define NRF_SPU          NRF_SPU_S
+#define NRF_TAD          NRF_TAD_S
+#define NRF_UICR         NRF_UICR_S
+#endif
+
+/* Fixups for the GPIOTE driver. */
+#if defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_GPIOTE        NRF_GPIOTE1
+#define GPIOTE_IRQHandler GPIOTE1_IRQHandler
+#else
+#define NRF_GPIOTE        NRF_GPIOTE0
+#define GPIOTE_IRQHandler GPIOTE0_IRQHandler
+#endif
+
+/* Fixups for the QDEC driver. */
+#define NRF_QDEC        NRF_QDEC0
+#define QDEC_IRQHandler QDEC0_IRQHandler
+
+// <<< Use Configuration Wizard in Context Menu >>>\n
+
+// <h> nRF_Drivers
+
+// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver.
+//==========================================================
+#ifndef NRFX_CLOCK_ENABLED
+#define NRFX_CLOCK_ENABLED 0
+#endif
+// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF clock source.
+
+// <0=> ULP
+// <1=> RC
+// <2=> XTAL
+// <3=> Synth
+
+#ifndef NRFX_CLOCK_CONFIG_LF_SRC
+#define NRFX_CLOCK_CONFIG_LF_SRC 2
+#endif
+
+// <q> NRFX_CLOCK_CONFIG_LF_CAL_ENABLED  - Enables LF Clock Calibration Support
+
+#ifndef NRFX_CLOCK_CONFIG_LF_CAL_ENABLED
+#define NRFX_CLOCK_CONFIG_LF_CAL_ENABLED 0
+#endif
+
+// <q> NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED - Enables two-stage LFXO start procedure
+
+// <i> If set to a non-zero value, LFRC will be started before LFXO and corresponding
+// <i> event will be generated. It means that CPU will be woken up when LFRC
+// <i> oscillator starts, but user callback will be invoked only after LFXO
+// <i> finally starts.
+
+#ifndef NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED
+#define NRFX_CLOCK_CONFIG_LFXO_TWO_STAGE_ENABLED 0
+#endif
+
+// <o> NRFX_CLOCK_CONFIG_HFCLK192M_SRC  - HFCLK192M source.
+
+// <0=> HFINT
+// <1=> HFXO
+
+#ifndef NRFX_CLOCK_CONFIG_HFCLK192M_SRC
+#define NRFX_CLOCK_CONFIG_HFCLK192M_SRC 1
+#endif
+
+// <o> NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_CLOCK_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
+#define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
+#define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
+#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
+#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_COMP_ENABLED - nrfx_comp - COMP peripheral driver
+//==========================================================
+#ifndef NRFX_COMP_ENABLED
+#define NRFX_COMP_ENABLED 0
+#endif
+
+// <o> NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_COMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_COMP_CONFIG_LOG_ENABLED
+#define NRFX_COMP_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_COMP_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_COMP_CONFIG_LOG_LEVEL
+#define NRFX_COMP_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_COMP_CONFIG_INFO_COLOR
+#define NRFX_COMP_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_COMP_CONFIG_DEBUG_COLOR
+#define NRFX_COMP_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_DPPI_ENABLED - nrfx_dppi - DPPI allocator.
+//==========================================================
+#ifndef NRFX_DPPI_ENABLED
+#define NRFX_DPPI_ENABLED 0
+#endif
+// <e> NRFX_DPPI_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_DPPI_CONFIG_LOG_ENABLED
+#define NRFX_DPPI_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_DPPI_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_DPPI_CONFIG_LOG_LEVEL
+#define NRFX_DPPI_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_DPPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_DPPI_CONFIG_INFO_COLOR
+#define NRFX_DPPI_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_DPPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_DPPI_CONFIG_DEBUG_COLOR
+#define NRFX_DPPI_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_EGU_ENABLED - nrfx_egu - EGU peripheral driver.
+//==========================================================
+#ifndef NRFX_EGU_ENABLED
+#define NRFX_EGU_ENABLED 0
+#endif
+
+// <q> NRFX_EGU0_ENABLED  - Enable EGU0 instance.
+
+#ifndef NRFX_EGU0_ENABLED
+#define NRFX_EGU0_ENABLED 0
+#endif
+
+// <q> NRFX_EGU1_ENABLED  - Enable EGU1 instance.
+
+#ifndef NRFX_EGU1_ENABLED
+#define NRFX_EGU1_ENABLED 0
+#endif
+
+// <q> NRFX_EGU2_ENABLED  - Enable EGU2 instance.
+
+#ifndef NRFX_EGU2_ENABLED
+#define NRFX_EGU2_ENABLED 0
+#endif
+
+// <q> NRFX_EGU3_ENABLED  - Enable EGU3 instance.
+
+#ifndef NRFX_EGU3_ENABLED
+#define NRFX_EGU3_ENABLED 0
+#endif
+
+// <q> NRFX_EGU4_ENABLED  - Enable EGU4 instance.
+
+#ifndef NRFX_EGU4_ENABLED
+#define NRFX_EGU4_ENABLED 0
+#endif
+
+// <q> NRFX_EGU5_ENABLED  - Enable EGU5 instance.
+
+#ifndef NRFX_EGU5_ENABLED
+#define NRFX_EGU5_ENABLED 0
+#endif
+
+// <o> NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_EGU_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// </e>
+
+// <e> NRFX_GPIOTE_ENABLED - nrfx_gpiote - GPIOTE peripheral driver.
+//==========================================================
+#ifndef NRFX_GPIOTE_ENABLED
+#define NRFX_GPIOTE_ENABLED 1
+#endif
+
+// <o> NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS - Number of dedicated handlers
+#ifndef NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS
+#define NRFX_GPIOTE_CONFIG_NUM_OF_EVT_HANDLERS 2
+#endif
+
+// <o> NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_GPIOTE_CONFIG_LOG_ENABLED
+#define NRFX_GPIOTE_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_GPIOTE_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_GPIOTE_CONFIG_LOG_LEVEL
+#define NRFX_GPIOTE_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_GPIOTE_CONFIG_INFO_COLOR
+#define NRFX_GPIOTE_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_GPIOTE_CONFIG_DEBUG_COLOR
+#define NRFX_GPIOTE_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_I2S_ENABLED - nrfx_i2s - I2S peripheral driver.
+//==========================================================
+#ifndef NRFX_I2S_ENABLED
+#define NRFX_I2S_ENABLED 0
+#endif
+
+// <o> NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_I2S_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_I2S_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_I2S_CONFIG_LOG_ENABLED
+#define NRFX_I2S_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_I2S_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_I2S_CONFIG_LOG_LEVEL
+#define NRFX_I2S_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_I2S_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_I2S_CONFIG_INFO_COLOR
+#define NRFX_I2S_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_I2S_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_I2S_CONFIG_DEBUG_COLOR
+#define NRFX_I2S_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_IPC_ENABLED - nrfx_ipc - IPC peripheral driver
+//==========================================================
+#ifndef NRFX_IPC_ENABLED
+#define NRFX_IPC_ENABLED 0
+#endif
+
+// </e>
+
+// <e> NRFX_LPCOMP_ENABLED - nrfx_lpcomp - LPCOMP peripheral driver
+//==========================================================
+#ifndef NRFX_LPCOMP_ENABLED
+#define NRFX_LPCOMP_ENABLED 0
+#endif
+
+// <o> NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_LPCOMP_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_LPCOMP_CONFIG_LOG_ENABLED
+#define NRFX_LPCOMP_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_LPCOMP_CONFIG_LOG_LEVEL
+#define NRFX_LPCOMP_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_LPCOMP_CONFIG_INFO_COLOR
+#define NRFX_LPCOMP_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_LPCOMP_CONFIG_DEBUG_COLOR
+#define NRFX_LPCOMP_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_NFCT_ENABLED - nrfx_nfct - NFCT peripheral driver
+//==========================================================
+#ifndef NRFX_NFCT_ENABLED
+#define NRFX_NFCT_ENABLED 0
+#endif
+// <o> NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_NFCT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <o> NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID - Timer instance used for workarounds in the driver.
+
+// <0=> 0
+// <1=> 1
+// <2=> 2
+
+#ifndef NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID
+#define NRFX_NFCT_CONFIG_TIMER_INSTANCE_ID 2
+#endif
+
+// <e> NRFX_NFCT_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_NFCT_CONFIG_LOG_ENABLED
+#define NRFX_NFCT_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_NFCT_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_NFCT_CONFIG_LOG_LEVEL
+#define NRFX_NFCT_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_NFCT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_NFCT_CONFIG_INFO_COLOR
+#define NRFX_NFCT_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_NFCT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_NFCT_CONFIG_DEBUG_COLOR
+#define NRFX_NFCT_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_NVMC_ENABLED - nrfx_nvmc - NVMC peripheral driver
+//==========================================================
+#ifndef NRFX_NVMC_ENABLED
+#define NRFX_NVMC_ENABLED 0
+#endif
+
+// </e>
+
+// <e> NRFX_PDM_ENABLED - nrfx_pdm - PDM peripheral driver.
+//==========================================================
+#ifndef NRFX_PDM_ENABLED
+#define NRFX_PDM_ENABLED 0
+#endif
+
+// <o> NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_PDM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_PDM_CONFIG_LOG_ENABLED
+#define NRFX_PDM_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_PDM_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_PDM_CONFIG_LOG_LEVEL
+#define NRFX_PDM_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PDM_CONFIG_INFO_COLOR
+#define NRFX_PDM_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PDM_CONFIG_DEBUG_COLOR
+#define NRFX_PDM_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver.
+//==========================================================
+#ifndef NRFX_POWER_ENABLED
+#define NRFX_POWER_ENABLED 0
+#endif
+// <o> NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_POWER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// </e>
+
+// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing (PRS) module.
+//==========================================================
+#ifndef NRFX_PRS_ENABLED
+#define NRFX_PRS_ENABLED 0
+#endif
+// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
+
+
+#ifndef NRFX_PRS_BOX_0_ENABLED
+#define NRFX_PRS_BOX_0_ENABLED 0
+#endif
+
+// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
+
+
+#ifndef NRFX_PRS_BOX_1_ENABLED
+#define NRFX_PRS_BOX_1_ENABLED 0
+#endif
+
+// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
+
+
+#ifndef NRFX_PRS_BOX_2_ENABLED
+#define NRFX_PRS_BOX_2_ENABLED 0
+#endif
+
+// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
+
+
+#ifndef NRFX_PRS_BOX_3_ENABLED
+#define NRFX_PRS_BOX_3_ENABLED 0
+#endif
+
+// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
+
+
+#ifndef NRFX_PRS_BOX_4_ENABLED
+#define NRFX_PRS_BOX_4_ENABLED 0
+#endif
+
+
+// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_PRS_CONFIG_LOG_ENABLED
+#define NRFX_PRS_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_PRS_CONFIG_LOG_LEVEL
+#define NRFX_PRS_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PRS_CONFIG_INFO_COLOR
+#define NRFX_PRS_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
+#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_PWM_ENABLED - nrfx_pwm - PWM peripheral driver.
+//==========================================================
+#ifndef NRFX_PWM_ENABLED
+#define NRFX_PWM_ENABLED 0
+#endif
+// <q> NRFX_PWM0_ENABLED  - Enables PWM0 instance.
+
+
+#ifndef NRFX_PWM0_ENABLED
+#define NRFX_PWM0_ENABLED 0
+#endif
+
+// <q> NRFX_PWM1_ENABLED  - Enables PWM1 instance.
+
+
+#ifndef NRFX_PWM1_ENABLED
+#define NRFX_PWM1_ENABLED 0
+#endif
+
+// <q> NRFX_PWM2_ENABLED  - Enables PWM2 instance.
+
+
+#ifndef NRFX_PWM2_ENABLED
+#define NRFX_PWM2_ENABLED 0
+#endif
+
+// <q> NRFX_PWM3_ENABLED  - Enables PWM3 instance.
+
+
+#ifndef NRFX_PWM3_ENABLED
+#define NRFX_PWM3_ENABLED 0
+#endif
+
+// <o> NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_PWM_CONFIG_LOG_ENABLED
+#define NRFX_PWM_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_PWM_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_PWM_CONFIG_LOG_LEVEL
+#define NRFX_PWM_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PWM_CONFIG_INFO_COLOR
+#define NRFX_PWM_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_PWM_CONFIG_DEBUG_COLOR
+#define NRFX_PWM_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_QDEC_ENABLED - nrfx_qdec - QDEC peripheral driver
+//==========================================================
+#ifndef NRFX_QDEC_ENABLED
+#define NRFX_QDEC_ENABLED 0
+#endif
+
+// <o> NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_QDEC_CONFIG_LOG_ENABLED
+#define NRFX_QDEC_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_QDEC_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_QDEC_CONFIG_LOG_LEVEL
+#define NRFX_QDEC_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_QDEC_CONFIG_INFO_COLOR
+#define NRFX_QDEC_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_QDEC_CONFIG_DEBUG_COLOR
+#define NRFX_QDEC_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
+//==========================================================
+#ifndef NRFX_QSPI_ENABLED
+#define NRFX_QSPI_ENABLED 0
+#endif
+
+// <o> NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_QSPI_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// </e>
+
+// <e> NRFX_RTC_ENABLED - nrfx_rtc - RTC peripheral driver.
+//==========================================================
+#ifndef NRFX_RTC_ENABLED
+#define NRFX_RTC_ENABLED 0
+#endif
+// <q> NRFX_RTC0_ENABLED  - Enables RTC0 instance.
+
+
+#ifndef NRFX_RTC0_ENABLED
+#define NRFX_RTC0_ENABLED 0
+#endif
+
+// <q> NRFX_RTC1_ENABLED  - Enables RTC1 instance.
+
+
+#ifndef NRFX_RTC1_ENABLED
+#define NRFX_RTC1_ENABLED 0
+#endif
+
+// <o> NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_RTC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_RTC_CONFIG_LOG_ENABLED
+#define NRFX_RTC_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_RTC_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_RTC_CONFIG_LOG_LEVEL
+#define NRFX_RTC_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_RTC_CONFIG_INFO_COLOR
+#define NRFX_RTC_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_RTC_CONFIG_DEBUG_COLOR
+#define NRFX_RTC_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver.
+//==========================================================
+#ifndef NRFX_SAADC_ENABLED
+#define NRFX_SAADC_ENABLED 0
+#endif
+
+// <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
+#define NRFX_SAADC_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
+#define NRFX_SAADC_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
+#define NRFX_SAADC_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
+#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_SPIM_ENABLED - nrfx_spim - SPIM peripheral driver.
+//==========================================================
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
+// <q> NRFX_SPIM0_ENABLED  - Enables SPIM0 instance.
+
+
+#ifndef NRFX_SPIM0_ENABLED
+#define NRFX_SPIM0_ENABLED 0
+#endif
+
+// <q> NRFX_SPIM1_ENABLED  - Enables SPIM1 instance.
+
+
+#ifndef NRFX_SPIM1_ENABLED
+#define NRFX_SPIM1_ENABLED 0
+#endif
+
+// <q> NRFX_SPIM2_ENABLED  - Enables SPIM2 instance.
+
+
+#ifndef NRFX_SPIM2_ENABLED
+#define NRFX_SPIM2_ENABLED 0
+#endif
+
+// <q> NRFX_SPIM3_ENABLED  - Enables SPIM3 instance.
+
+
+#ifndef NRFX_SPIM3_ENABLED
+#define NRFX_SPIM3_ENABLED 0
+#endif
+
+// <q> NRFX_SPIM4_ENABLED  - Enables SPIM4 instance.
+
+
+#ifndef NRFX_SPIM4_ENABLED
+#define NRFX_SPIM4_ENABLED 0
+#endif
+
+// <q> NRFX_SPIM_EXTENDED_ENABLED  - Enable extended SPIM features
+
+
+#ifndef NRFX_SPIM_EXTENDED_ENABLED
+#define NRFX_SPIM_EXTENDED_ENABLED 0
+#endif
+
+// <o> NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_SPIM_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_SPIM_CONFIG_LOG_ENABLED
+#define NRFX_SPIM_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_SPIM_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_SPIM_CONFIG_LOG_LEVEL
+#define NRFX_SPIM_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_SPIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIM_CONFIG_INFO_COLOR
+#define NRFX_SPIM_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_SPIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIM_CONFIG_DEBUG_COLOR
+#define NRFX_SPIM_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver.
+//==========================================================
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+// <q> NRFX_SPIS0_ENABLED  - Enables SPIS0 instance.
+
+
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 0
+#endif
+
+// <q> NRFX_SPIS1_ENABLED  - Enables SPIS1 instance.
+
+
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+// <q> NRFX_SPIS2_ENABLED  - Enables SPIS2 instance.
+
+
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
+
+// <q> NRFX_SPIS3_ENABLED  - Enables SPIS3 instance.
+
+
+#ifndef NRFX_SPIS3_ENABLED
+#define NRFX_SPIS3_ENABLED 0
+#endif
+
+// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
+#define NRFX_SPIS_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
+#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <q> NRFX_SYSTICK_ENABLED  - nrfx_systick - ARM(R) SysTick driver.
+
+
+#ifndef NRFX_SYSTICK_ENABLED
+#define NRFX_SYSTICK_ENABLED 0
+#endif
+
+// <e> NRFX_TIMER_ENABLED - nrfx_timer - TIMER periperal driver.
+//==========================================================
+#ifndef NRFX_TIMER_ENABLED
+#define NRFX_TIMER_ENABLED 0
+#endif
+// <q> NRFX_TIMER0_ENABLED  - Enables TIMER0 instance.
+
+
+#ifndef NRFX_TIMER0_ENABLED
+#define NRFX_TIMER0_ENABLED 0
+#endif
+
+// <q> NRFX_TIMER1_ENABLED  - Enables TIMER1 instance.
+
+
+#ifndef NRFX_TIMER1_ENABLED
+#define NRFX_TIMER1_ENABLED 1
+#endif
+
+// <q> NRFX_TIMER2_ENABLED  - Enables TIMER2 instance.
+
+
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 0
+#endif
+
+// <o> NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_TIMER_CONFIG_LOG_ENABLED
+#define NRFX_TIMER_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_TIMER_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_TIMER_CONFIG_LOG_LEVEL
+#define NRFX_TIMER_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TIMER_CONFIG_INFO_COLOR
+#define NRFX_TIMER_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TIMER_CONFIG_DEBUG_COLOR
+#define NRFX_TIMER_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver.
+//==========================================================
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 1
+#endif
+// <q> NRFX_TWIM0_ENABLED  - Enables TWIM0 instance.
+
+
+#ifndef NRFX_TWIM0_ENABLED
+#define NRFX_TWIM0_ENABLED 0
+#endif
+
+// <q> NRFX_TWIM1_ENABLED  - Enables TWIM1 instance.
+
+
+#ifndef NRFX_TWIM1_ENABLED
+#define NRFX_TWIM1_ENABLED 0
+#endif
+
+// <q> NRFX_TWIM2_ENABLED  - Enables TWIM2 instance.
+
+
+#ifndef NRFX_TWIM2_ENABLED
+#define NRFX_TWIM2_ENABLED 1
+#endif
+
+// <q> NRFX_TWIM3_ENABLED  - Enables TWIM3 instance.
+
+
+#ifndef NRFX_TWIM3_ENABLED
+#define NRFX_TWIM3_ENABLED 1
+#endif
+
+// <o> NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_TWIM_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_TWIM_CONFIG_LOG_ENABLED
+#define NRFX_TWIM_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_TWIM_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_TWIM_CONFIG_LOG_LEVEL
+#define NRFX_TWIM_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_TWIM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TWIM_CONFIG_INFO_COLOR
+#define NRFX_TWIM_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_TWIM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TWIM_CONFIG_DEBUG_COLOR
+#define NRFX_TWIM_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_TWIS_ENABLED - nrfx_twis - TWIS peripheral driver.
+//==========================================================
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
+#endif
+
+// <q> NRFX_TWIS0_ENABLED  - Enables TWIS0 instance.
+
+#ifndef NRFX_TWIS0_ENABLED
+#define NRFX_TWIS0_ENABLED 0
+#endif
+
+// <q> NRFX_TWIS1_ENABLED  - Enables TWIS1 instance.
+
+#ifndef NRFX_TWIS1_ENABLED
+#define NRFX_TWIS1_ENABLED 0
+#endif
+
+// <q> NRFX_TWIS2_ENABLED  - Enables TWIS2 instance.
+
+#ifndef NRFX_TWIS2_ENABLED
+#define NRFX_TWIS2_ENABLED 0
+#endif
+
+// <q> NRFX_TWIS3_ENABLED  - Enables TWIS3 instance.
+
+#ifndef NRFX_TWIS3_ENABLED
+#define NRFX_TWIS3_ENABLED 0
+#endif
+
+// <q> NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY  - Assumes that any instance would be initialized only once.
+
+// <i> Optimization flag. Registers used by TWIS are shared by other peripherals. Normally, during initialization driver tries to clear all registers to known state before doing the initialization itself. This gives initialization safe procedure, no matter when it would be called. If you activate TWIS only once and do never uninitialize it - set this flag to 1 what gives more optimal code.
+
+#ifndef NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY
+#define NRFX_TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+#endif
+
+// <q> NRFX_TWIS_NO_SYNC_MODE  - Removes support for synchronous mode.
+
+// <i> Synchronous mode would be used in specific situations. And it uses some additional code and data memory to safely process state machine by polling it in status functions. If this functionality is not required it may be disabled to free some resources.
+
+#ifndef NRFX_TWIS_NO_SYNC_MODE
+#define NRFX_TWIS_NO_SYNC_MODE 0
+#endif
+
+// <o> NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_TWIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_TWIS_CONFIG_LOG_ENABLED
+#define NRFX_TWIS_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_TWIS_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_TWIS_CONFIG_LOG_LEVEL
+#define NRFX_TWIS_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TWIS_CONFIG_INFO_COLOR
+#define NRFX_TWIS_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_TWIS_CONFIG_DEBUG_COLOR
+#define NRFX_TWIS_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver.
+//==========================================================
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 1
+#endif
+// <o> NRFX_UARTE0_ENABLED - Enables UARTE0 instances
+#ifndef NRFX_UARTE0_ENABLED
+#define NRFX_UARTE0_ENABLED 1
+#endif
+
+// <o> NRFX_UARTE1_ENABLED - Enables UARTE1 instance.
+#ifndef NRFX_UARTE1_ENABLED
+#define NRFX_UARTE1_ENABLED 1
+#endif
+
+// <o> NRFX_UARTE2_ENABLED - Enables UARTE2 instance.
+#ifndef NRFX_UARTE2_ENABLED
+#define NRFX_UARTE2_ENABLED 0
+#endif
+
+// <o> NRFX_UARTE3_ENABLED - Enables UARTE3 instance.
+#ifndef NRFX_UARTE3_ENABLED
+#define NRFX_UARTE3_ENABLED 0
+#endif
+
+// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
+#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
+#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
+#define NRFX_UARTE_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
+#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_USBD_ENABLED - nrfx_usbd - USBD peripheral driver
+//==========================================================
+#ifndef NRFX_USBD_ENABLED
+#define NRFX_USBD_ENABLED 0
+#endif
+// <o> NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_USBD_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
+
+// <i> This option gives priority to isochronous transfers.
+// <i> Enabling it assures that isochronous transfers are always processed,
+// <i> even if multiple other transfers are pending.
+// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
+// <i> function is called, so the option is independent of the algorithm chosen.
+
+#ifndef NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST
+#define NRFX_USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
+#endif
+
+// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
+
+
+// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
+// <i> Else, there will be no response.
+
+#ifndef NRFX_USBD_CONFIG_ISO_IN_ZLP
+#define NRFX_USBD_CONFIG_ISO_IN_ZLP 0
+#endif
+
+// <e> NRFX_USBD_CONFIG_LOG_ENABLED - Enable logging in the module
+//==========================================================
+#ifndef NRFX_USBD_CONFIG_LOG_ENABLED
+#define NRFX_USBD_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_USBD_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_USBD_CONFIG_LOG_LEVEL
+#define NRFX_USBD_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_USBD_CONFIG_INFO_COLOR
+#define NRFX_USBD_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_USBD_CONFIG_DEBUG_COLOR
+#define NRFX_USBD_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_USBREG_ENABLED - nrfx_usbreg - USBREG peripheral driver
+//==========================================================
+#ifndef NRFX_USBREG_ENABLED
+#define NRFX_USBREG_ENABLED 0
+#endif
+// <o> NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_USBREG_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRFX_WDT_ENABLED - nrfx_wdt - WDT peripheral driver.
+//==========================================================
+#ifndef NRFX_WDT_ENABLED
+#define NRFX_WDT_ENABLED 0
+#endif
+// <q> NRFX_WDT0_ENABLED  - Enable WDT0 instance.
+
+
+#ifndef NRFX_WDT0_ENABLED
+#define NRFX_WDT0_ENABLED 0
+#endif
+
+// <q> NRFX_WDT1_ENABLED  - Enable WDT1 instance.
+
+
+#ifndef NRFX_WDT1_ENABLED
+#define NRFX_WDT1_ENABLED 0
+#endif
+
+// <o> NRFX_WDT_CONFIG_NO_IRQ  - Remove WDT IRQ handling from WDT driver.
+
+// <0=> Include WDT IRQ handling
+// <1=> Remove WDT IRQ handling
+
+#ifndef NRFX_WDT_CONFIG_NO_IRQ
+#define NRFX_WDT_CONFIG_NO_IRQ 0
+#endif
+
+// <o> NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_WDT_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <e> NRFX_WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_WDT_CONFIG_LOG_ENABLED
+#define NRFX_WDT_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_WDT_CONFIG_LOG_LEVEL  - Default severity level.
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_WDT_CONFIG_LOG_LEVEL
+#define NRFX_WDT_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_WDT_CONFIG_INFO_COLOR
+#define NRFX_WDT_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_WDT_CONFIG_DEBUG_COLOR
+#define NRFX_WDT_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// </h>
+
+#endif // NRFX_CONFIG_NRF5340_APPLICATION_H__

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -24,6 +24,10 @@
 
 static bool nrfx_twim_in_use[TWIM_COUNT] = {false};
 
+int nrfx_error = 0;
+i2c_t *nrfx_obj = NULL;
+int nrfx_function = 0;
+
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
     MBED_ASSERT(obj);
@@ -32,7 +36,6 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
     for (uint8_t index = 0; index < TWIM_COUNT; ++index) {
         if (!nrfx_twim_in_use[index]) {
-            nrfx_twim_in_use[index] = true;
             switch (index) {
 #if NRFX_CHECK(NRFX_TWIM0_ENABLED)
                 case 0: {
@@ -63,20 +66,25 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
                 }
 #endif
                 default:
-                    break;
+                    continue;
             }
+            nrfx_twim_in_use[index] = true;
             break;
         }
     }
     MBED_ASSERT(obj->instance.drv_inst_idx < NRFX_UARTE_ENABLED_COUNT);
+    //obj->instance.p_twim = NRF_TWIM2_NS;
+    nrfx_obj = obj;
 
     nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl, sda);
     memcpy(&obj->config, &config, sizeof(obj->config));
-    nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
+    int error = nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
+    nrfx_error = error;
 }
 
 void i2c_frequency(i2c_t *obj, int hz)
 {
+    nrfx_function = 1;
     nrfx_twim_uninit(&obj->instance);
 
     switch (hz) {
@@ -104,26 +112,31 @@ void i2c_frequency(i2c_t *obj, int hz)
 
 int i2c_start(i2c_t *obj)
 {
-    return 0;
+    nrfx_function = 2;
+    return -1;
 }
 
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    return 0;
+    nrfx_function = 3;
+    return -1;
 }
 
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    return 0;
+    nrfx_function = 4;
+    return -1;
 }
 
 int i2c_stop(i2c_t *obj)
 {
-    return 0;
+    nrfx_function = 5;
+    return -1;
 }
 
 void i2c_reset(i2c_t *obj)
 {
+    nrfx_function = 6;
     uint8_t index = obj->instance.drv_inst_idx;
     nrfx_twim_uninit(&obj->instance);
     nrfx_twim_in_use[index] = false;
@@ -131,15 +144,20 @@ void i2c_reset(i2c_t *obj)
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    return 0;
+    nrfx_function = 7;
+    while(nrfx_twim_is_busy(&obj->instance));
+    nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_RX(address, (uint8_t *)data, length);
+    int error = nrfx_twim_xfer(&obj->instance, &descriptor, 0);
+    return error ? -error : length;
 }
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    while(!nrfx_twim_is_busy(&obj->instance));
+    nrfx_function = 8;
+    while(nrfx_twim_is_busy(&obj->instance));
     nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_TX(address, (uint8_t *)data, length);
     int error = nrfx_twim_xfer(&obj->instance, &descriptor, stop ? 0 : NRFX_TWIM_FLAG_TX_NO_STOP);
-    return error ? error : length;
+    return error ? -error : length;
 }
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -24,9 +24,27 @@
 
 static bool nrfx_twim_in_use[TWIM_COUNT] = {false};
 
-int nrfx_error = 0;
-i2c_t *nrfx_obj = NULL;
-int nrfx_function = 0;
+static void i2c_event_handler(const nrfx_twim_evt_t* event, void* context)
+{
+    i2c_t *obj = (i2c_t *)context;
+    if (obj) {
+        switch (event->type) {
+            case NRFX_TWIM_EVT_DONE:
+                obj->transfer_result = event->xfer_desc.primary_length;
+                break;
+            case NRFX_TWIM_EVT_ADDRESS_NACK:
+            case NRFX_TWIM_EVT_DATA_NACK:
+                obj->transfer_result = I2C_ERROR_NO_SLAVE;
+                break;
+            case NRFX_TWIM_EVT_OVERRUN:
+            case NRFX_TWIM_EVT_BUS_ERROR:
+                obj->transfer_result = I2C_ERROR_BUS_BUSY;
+                break;
+        }
+
+        obj->transfer_complete = true;
+    }
+}
 
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
@@ -73,18 +91,15 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
         }
     }
     MBED_ASSERT(obj->instance.drv_inst_idx < NRFX_UARTE_ENABLED_COUNT);
-    //obj->instance.p_twim = NRF_TWIM2_NS;
-    nrfx_obj = obj;
 
     nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl, sda);
     memcpy(&obj->config, &config, sizeof(obj->config));
-    int error = nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
-    nrfx_error = error;
+    nrfx_twim_init(&obj->instance, &obj->config, i2c_event_handler, obj);
+    nrfx_twim_enable(&obj->instance);
 }
 
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    nrfx_function = 1;
     nrfx_twim_uninit(&obj->instance);
 
     switch (hz) {
@@ -107,36 +122,47 @@ void i2c_frequency(i2c_t *obj, int hz)
             break;
     }
 
-    nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
+    nrfx_twim_init(&obj->instance, &obj->config, i2c_event_handler, obj);
+    nrfx_twim_enable(&obj->instance);
 }
 
 int i2c_start(i2c_t *obj)
 {
-    nrfx_function = 2;
-    return -1;
+    obj->length = 0;
+    obj->address = 0;
+    return 0;
 }
 
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    nrfx_function = 3;
-    return -1;
+    /* The TWIM driver does not support single byte writes so combine the bytes and send on i2c_stop() */
+    if (obj->address == 0) {
+        obj->address = data;
+    } else if (obj->length < sizeof(obj->buffer)) {
+        obj->buffer[obj->length++] = data;
+    } else {
+        return 0;
+    }
+
+    return 1;
 }
 
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    nrfx_function = 4;
-    return -1;
+    return I2C_ERROR_NO_SLAVE;
 }
 
 int i2c_stop(i2c_t *obj)
 {
-    nrfx_function = 5;
-    return -1;
+    if (obj->length) {
+        i2c_write(obj, obj->address, &obj->buffer[0], obj->length, true);
+    }
+
+    return 0;
 }
 
 void i2c_reset(i2c_t *obj)
 {
-    nrfx_function = 6;
     uint8_t index = obj->instance.drv_inst_idx;
     nrfx_twim_uninit(&obj->instance);
     nrfx_twim_in_use[index] = false;
@@ -144,20 +170,30 @@ void i2c_reset(i2c_t *obj)
 
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    nrfx_function = 7;
     while(nrfx_twim_is_busy(&obj->instance));
+
+    obj->transfer_complete = false;
     nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_RX(address, (uint8_t *)data, length);
-    int error = nrfx_twim_xfer(&obj->instance, &descriptor, 0);
-    return error ? -error : length;
+    if (nrfx_twim_xfer(&obj->instance, &descriptor, 0)) {
+        return I2C_ERROR_BUS_BUSY;
+    }
+
+    while(!obj->transfer_complete);
+    return obj->transfer_result;
 }
 
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    nrfx_function = 8;
     while(nrfx_twim_is_busy(&obj->instance));
+
+    obj->transfer_complete = false;
     nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_TX(address, (uint8_t *)data, length);
-    int error = nrfx_twim_xfer(&obj->instance, &descriptor, stop ? 0 : NRFX_TWIM_FLAG_TX_NO_STOP);
-    return error ? -error : length;
+    if (nrfx_twim_xfer(&obj->instance, &descriptor, stop ? 0 : NRFX_TWIM_FLAG_TX_NO_STOP)) {
+        return I2C_ERROR_BUS_BUSY;
+    }
+
+    while(!obj->transfer_complete);
+    return obj->transfer_result;
 }
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -1,1170 +1,145 @@
-/*
- * Copyright (c) 2017 Nordic Semiconductor ASA
- * All rights reserved.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   1. Redistributions of source code must retain the above copyright notice, this list
- *      of conditions and the following disclaimer.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
- *      integrated circuit in a product or a software update for such product, must reproduce
- *      the above copyright notice, this list of conditions and the following disclaimer in
- *      the documentation and/or other materials provided with the distribution.
- *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
- *      used to endorse or promote products derived from this software without specific prior
- *      written permission.
- *
- *   4. This software, with or without modification, must only be used with a
- *      Nordic Semiconductor ASA integrated circuit.
- *
- *   5. Any software provided in binary or object form under this license must not be reverse
- *      engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+#if DEVICE_I2C
 
-#if DEVICE_I2C && DEVICE_LPTICKER
-/* I2C
- *
- * This HAL implementation uses the nrf_drv_twi.h API primarily but switches to TWI for the
- * low-level HAL functions. These calls can't be implemented with the TWIM due to the
- * different API.
- *
- * Known limitations:
- *  * The TWI/TWIM only supports 7-bit addresses.
- *  * The TWI API doesn't allow reading 1 byte. At least 2 bytes will be read.
- */
+#include <string.h>
 
 #include "i2c_api.h"
-#include "lp_ticker_api.h"
-
-#include "object_owners.h"
-#include "pinmap_ex.h"
-#include "PeripheralPins.h"
-
+#include "mbed_error.h"
 #include "nrfx_twim.h"
-#include "app_util_platform.h"
-#include "prs/nrfx_prs.h"
 
-#if DEVICE_I2CSLAVE
-#include "nrfx_twis.h"
-#endif
+static bool nrfx_twim_in_use[TWIM_COUNT] = {false};
 
-#define TWI_PIN_INIT(_pin) nrf_gpio_cfg((_pin),                     \
-                                        NRF_GPIO_PIN_DIR_INPUT,     \
-                                        NRF_GPIO_PIN_INPUT_CONNECT, \
-                                        NRF_GPIO_PIN_PULLUP,        \
-                                        NRF_GPIO_PIN_S0D1,          \
-                                        NRF_GPIO_PIN_NOSENSE)
-
-#if 0
-#define DEBUG_PRINTF(...) printf(__VA_ARGS__)
-#else
-#define DEBUG_PRINTF(...)
-#endif
-
-#define MAXIMUM_TIMEOUT_US (10000)  // timeout for waiting for RX/TX
-#define I2C_READ_BIT 0x01           // read bit
-
-static uint32_t tick2us = 1;
-
-/* Keep track of what mode the peripheral is in. On NRF52, Driver mode can use TWIM. */
-typedef enum {
-    NORDIC_I2C_MODE_NONE,
-    NORDIC_I2C_MODE_TWI,
-    NORDIC_I2C_MODE_DRIVER
-} nordic_nrf5_mode_t;
-
-/* In simple mode, the Start signal is sent on the first write call due to hardware limitations. */
-typedef enum {
-    NORDIC_TWI_STATE_IDLE,
-    NORDIC_TWI_STATE_START,
-    NORDIC_TWI_STATE_BUSY
-} nordic_nrf5_twi_state_t;
-
-/* Forward declaration. These functions are implemented in the driver but not
- * set up in the NVIC due to it being relocated.
- */
-void SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler(void);
-void SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler(void);
-
-/** Initialize the I2C peripheral. It sets the default parameters for I2C
- *  peripheral, and configures its specifieds pins.
- *
- *  @param obj  The I2C object
- *  @param sda  The sda pin
- *  @param scl  The scl pin
- */
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
-    DEBUG_PRINTF("i2c_init: %p %d %d\r\n", obj, sda, scl);
+    MBED_ASSERT(obj);
+    memset(obj, 0, sizeof(*obj));
+    obj->instance.drv_inst_idx = NRFX_TWIM_ENABLED_COUNT;
 
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
+    for (uint8_t index = 0; index < TWIM_COUNT; ++index) {
+        if (!nrfx_twim_in_use[index]) {
+            nrfx_twim_in_use[index] = true;
+            switch (index) {
+#if NRFX_CHECK(NRFX_TWIM0_ENABLED)
+                case 0: {
+                    nrfx_twim_t instance0 = NRFX_TWIM_INSTANCE(0);
+                    memcpy(&obj->instance, &instance0, sizeof(obj->instance));
+                    break;
+                }
 #endif
-
-    const ticker_info_t *ti = lp_ticker_get_info();
-    tick2us = 1000000 / ti->frequency;
-
-    /* Get instance from pin configuration. */
-    int instance = pin_instance_i2c(sda, scl);
-    MBED_ASSERT(instance < NRFX_TWI_ENABLED_COUNT);
-
-    /* Initialize i2c_t object */
-    config->instance = instance;
-    config->sda = sda;
-    config->scl = scl;
-    config->frequency = NRF_TWIM_FREQ_100K;
-    config->state = NORDIC_TWI_STATE_IDLE;
-    config->mode = NORDIC_I2C_MODE_NONE;
-
-#if DEVICE_I2C_ASYNCH
-    config->handler = 0;
-    config->event = 0;
-    config->mask = 0;
+#if NRFX_CHECK(NRFX_TWIM1_ENABLED)
+                case 1: {
+                    nrfx_twim_t instance1 = NRFX_TWIM_INSTANCE(1);
+                    memcpy(&obj->instance, &instance1, sizeof(obj->instance));
+                    break;
+                }
 #endif
-
-#if DEVICE_I2CSLAVE
-    /** was_slave is used to decide which driver call we need
-     * to use when uninitializing a given instance
-     */
-    config->was_slave = false;
-    config->is_slave = false;
-    config->slave_addr = 0;
+#if NRFX_CHECK(NRFX_TWIM2_ENABLED)
+                case 2: {
+                    nrfx_twim_t instance2 = NRFX_TWIM_INSTANCE(2);
+                    memcpy(&obj->instance, &instance2, sizeof(obj->instance));
+                    break;
+                }
 #endif
-
-    /* Force reconfiguration */
-    config->update = true;
-
-    static bool first_init = true;
-
-    if (first_init) {
-        first_init = false;
-
-        /* Register interrupt handlers in driver with the NVIC. */
-        NVIC_SetVector(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn, (uint32_t) SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler);
-        NVIC_SetVector(SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn, (uint32_t) SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler);
+#if NRFX_CHECK(NRFX_TWIM3_ENABLED)
+                case 3: {
+                    nrfx_twim_t instance3 = NRFX_TWIM_INSTANCE(3);
+                    memcpy(&obj->instance, &instance3, sizeof(obj->instance));
+                    break;
+                }
+#endif
+                default:
+                    break;
+            }
+            break;
+        }
     }
+    MBED_ASSERT(obj->instance.drv_inst_idx < NRFX_UARTE_ENABLED_COUNT);
+
+    nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl, sda);
+    memcpy(&obj->config, &config, sizeof(obj->config));
+    nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
 }
 
-/** Configure the I2C frequency
- *
- *  @param obj The I2C object
- *  @param hz  Frequency in Hz
- */
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    DEBUG_PRINTF("i2c_frequency: %p %d\r\n", obj, hz);
+    nrfx_twim_uninit(&obj->instance);
 
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
+    switch (hz) {
+        case 100000:
+            obj->config.frequency = NRF_TWIM_FREQ_100K;
+            break;
+        case 250000:
+            obj->config.frequency = NRF_TWIM_FREQ_250K;
+            break;
+        case 400000:
+            obj->config.frequency = NRF_TWIM_FREQ_400K;
+            break;
+#if NRF_TWIM_HAS_1000_KHZ_FREQ
+        case 1000000:
+            obj->config.frequency = NRF_TWIM_FREQ_1000K;
+            break;
 #endif
-
-
-#if DEVICE_I2CSLAVE
-    /* Slaves automatically get frequency from master, may be 100kHz or 400kHz */
-    if(config->is_slave) {
-    		return;
-    }
-#endif
-
-    /* Round down to nearest valid frequency. */
-    nrf_twi_frequency_t new_frequency;
-
-    if (hz < 250000) {
-        new_frequency = NRF_TWI_FREQ_100K;
-    } else if (hz < 400000) {
-        new_frequency = NRF_TWI_FREQ_250K;
-    } else {
-        new_frequency = NRF_TWI_FREQ_400K;
+        default:
+            MBED_WARNING1(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SERIAL, MBED_ERROR_CODE_UNSUPPORTED), "frequency not supported", hz);
+            break;
     }
 
-    /* Only store frequency in object. Configuration happens at the beginning of each transaction. */
-    config->frequency = new_frequency;
-    config->update = true;
+    nrfx_twim_init(&obj->instance, &obj->config, NULL, NULL);
 }
 
-static uint32_t byte_timeout(nrf_twi_frequency_t frequency)
-{
-    uint32_t timeout = 0;
-    // set timeout in [us] as: 10 [bits] * 1000000 / frequency
-    if (frequency == NRF_TWI_FREQ_100K) {
-        timeout = 100; // 10 * 10us
-    } else if (frequency == NRF_TWI_FREQ_250K) {
-        timeout = 40; // 10 * 4us
-    } else if (frequency == NRF_TWI_FREQ_400K) {
-        timeout = 25; // 10 * 2.5us
-    }
-
-    return timeout;
-}
-
-const PinMap *i2c_master_sda_pinmap()
-{
-    return PinMap_I2C_testing;
-}
-
-const PinMap *i2c_master_scl_pinmap()
-{
-    return PinMap_I2C_testing;
-}
-
-const PinMap *i2c_slave_sda_pinmap()
-{
-    return PinMap_I2C_testing;
-}
-
-const PinMap *i2c_slave_scl_pinmap()
-{
-    return PinMap_I2C_testing;
-}
-
-
-/***
- *       _____ _                 _        _________          _______
- *      / ____(_)               | |      |__   __\ \        / /_   _|
- *     | (___  _ _ __ ___  _ __ | | ___     | |   \ \  /\  / /  | |
- *      \___ \| | '_ ` _ \| '_ \| |/ _ \    | |    \ \/  \/ /   | |
- *      ____) | | | | | | | |_) | |  __/    | |     \  /\  /   _| |_
- *     |_____/|_|_| |_| |_| .__/|_|\___|    |_|      \/  \/   |_____|
- *                        | |
- *                        |_|
- */
-
-/*****************************************************************************/
-/* Simple API implementation using TWI                                       */
-/*****************************************************************************/
-
-/* Global array for easy register selection for each instance. */
-static NRF_TWI_Type *nordic_nrf5_twi_register[2] = { NRF_TWI0, NRF_TWI1 };
-
-/**
- * @brief      Reconfigure TWI register.
- *
- *             If the peripheral is enabled, it will be disabled first. All
- *             registers are cleared to their default values unless replaced
- *             by new configuration.
- *
- *             If the object is the owner, the mode hasn't changed, and the
- *             force change flag is false, all settings are kept unchanged.
- *
- * @param      obj           The object
- */
-void i2c_configure_twi_instance(i2c_t *obj)
-{
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    static nrfx_irq_handler_t const irq_handlers[NRFX_TWI_ENABLED_COUNT] = {
-#if NRFX_CHECK(NRFX_TWI0_ENABLED)
-        nrfx_twi_0_irq_handler,
-#endif
-#if NRFX_CHECK(NRFX_TWI1_ENABLED)
-        nrfx_twi_1_irq_handler,
-#endif
-    };
-
-    int instance = config->instance;
-
-    /* Get pointer to object of the current owner of the peripheral. */
-    void *current_owner = object_owner_spi2c_get(instance);
-
-    /* Check if reconfiguration is actually necessary. */
-    if ((obj != current_owner) || (config->mode != NORDIC_I2C_MODE_TWI) || config->update) {
-
-        DEBUG_PRINTF("i2c_configure_twi_instance: %p %p\r\n", obj, current_owner);
-
-        /* Claim ownership of peripheral. */
-        object_owner_spi2c_set(instance, obj);
-
-        /* Set current mode. */
-        config->mode = NORDIC_I2C_MODE_TWI;
-
-        /* Disable peripheral if it is currently enabled. */
-        if (nordic_nrf5_twi_register[instance]->ENABLE) {
-            nrf_twi_disable(nordic_nrf5_twi_register[instance]);
-        }
-
-        /* Force resource release. This is necessary because mbed drivers don't
-         * deinitialize on object destruction.
-         */
-        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const *)nordic_nrf5_twi_register[instance])));
-        /* Release and re-initialize the irq handlers.
-         * observation: based on call flow, this is called only during i2c_reset and i2c_byte_write
-         * The nrfx_prs_acquire is normally called in nrfx_twi_init which is part of the i2c_configure_driver_instance,
-         * not i2c_configure_twi_intance. Hence I think the release and acquire is not doing any useful work here.
-         * Keeping for reference and should clean up after testing if found not useful.
-        */
-
-        nrfx_prs_release(nordic_nrf5_twi_register[instance]);
-        if (nrfx_prs_acquire(nordic_nrf5_twi_register[instance],
-                             irq_handlers[instance]) != NRFX_SUCCESS) {
-            DEBUG_PRINTF("Function: %s, nrfx_prs_acquire error code: %s.",
-                         __func__,
-                         err_code);
-        }
-
-        /* Reset shorts register. */
-        nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], 0);
-
-        /* Disable all TWI interrupts. */
-        nrf_twi_int_disable(nordic_nrf5_twi_register[instance],
-                            NRF_TWI_INT_STOPPED_MASK  |
-                            NRF_TWI_INT_RXDREADY_MASK |
-                            NRF_TWI_INT_TXDSENT_MASK  |
-                            NRF_TWI_INT_ERROR_MASK    |
-                            NRF_TWI_INT_BB_MASK       |
-                            NRF_TWI_INT_SUSPENDED_MASK);
-
-        /* Clear error register. */
-        nrf_twi_errorsrc_get_and_clear(nordic_nrf5_twi_register[instance]);
-
-        /* Clear all previous events. */
-        nrf_twi_event_clear(nordic_nrf5_twi_register[instance],
-                            NRF_TWI_EVENT_STOPPED  |
-                            NRF_TWI_EVENT_RXDREADY |
-                            NRF_TWI_EVENT_TXDSENT  |
-                            NRF_TWI_EVENT_ERROR    |
-                            NRF_TWI_EVENT_BB       |
-                            NRF_TWI_EVENT_SUSPENDED);
-
-        /* Configure SDA and SCL pins. */
-        nrf_twi_pins_set(nordic_nrf5_twi_register[instance],
-                         config->scl,
-                         config->sda);
-
-        /* Set frequency. */
-        nrf_twi_frequency_set(nordic_nrf5_twi_register[instance],
-                              config->frequency);
-
-        /* To secure correct signal levels on the pins used by the TWI
-        master when the system is in OFF mode, and when the TWI master is
-        disabled, these pins must be configured in the GPIO peripheral.
-        */
-        TWI_PIN_INIT(config->scl);
-        TWI_PIN_INIT(config->sda);
-
-        /* Enable TWI peripheral with new settings. */
-        nrf_twi_enable(nordic_nrf5_twi_register[instance]);
-    }
-}
-
-/** Send START command
- *
- *  @param obj The I2C object
- */
 int i2c_start(i2c_t *obj)
 {
-    DEBUG_PRINTF("i2c_start: %p\r\n", obj);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    /* Change state but defer actual signaling until the first byte (the address)
-       is transmitted. This is due to hardware limitations.
-    */
-    config->state = NORDIC_TWI_STATE_START;
-
     return 0;
 }
 
-/** Write one byte
- *
- *  @param obj The I2C object
- *  @param data Byte to be written
- *  @return 0 if NAK was received, 1 if ACK was received, 2 for timeout.
- */
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    DEBUG_PRINTF("i2c_byte_write: %p %d\r\n", obj, data);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    NRF_TWI_Type *p_twi = nordic_nrf5_twi_register[config->instance];
-    int result = 1; // default to ACK
-    uint32_t start_us, now_us, timeout;
-
-    if (config->state == NORDIC_TWI_STATE_START) {
-        config->state = NORDIC_TWI_STATE_BUSY;
-
-        config->update = true;
-        i2c_configure_twi_instance(obj);
-
-        if (data & I2C_READ_BIT) {
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_STOPPED);
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_RXDREADY);
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_ERROR);
-            (void)nrf_twi_errorsrc_get_and_clear(p_twi);
-
-            nrf_twi_shorts_set(p_twi, NRF_TWI_SHORT_BB_SUSPEND_MASK);
-
-            nrf_twi_address_set(p_twi, data >> 1);
-            nrf_twi_task_trigger(p_twi, NRF_TWI_TASK_RESUME);
-            nrf_twi_task_trigger(p_twi, NRF_TWI_TASK_STARTRX);
-        } else {
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_STOPPED);
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_TXDSENT);
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_ERROR);
-            nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_BB);
-            (void)nrf_twi_errorsrc_get_and_clear(p_twi);
-
-            nrf_twi_shorts_set(p_twi, 0);
-
-            nrf_twi_address_set(p_twi, data >> 1);
-            nrf_twi_task_trigger(p_twi, NRF_TWI_TASK_RESUME);
-            nrf_twi_task_trigger(p_twi, NRF_TWI_TASK_STARTTX);
-        }
-        /* Wait two byte duration for address ACK */
-        timeout = 2 * byte_timeout(config->frequency);
-    } else {
-        nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_TXDSENT);
-        nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_ERROR);
-        nrf_twi_event_clear(p_twi, NRF_TWI_EVENT_BB);
-        (void)nrf_twi_errorsrc_get_and_clear(p_twi);
-
-        nrf_twi_task_trigger(p_twi, NRF_TWI_TASK_RESUME);
-        nrf_twi_txd_set(p_twi, data);
-        /* Wait ten byte duration for data ACK */
-        timeout = 10 * byte_timeout(config->frequency);
-    }
-
-    start_us = tick2us * lp_ticker_read();
-    now_us = start_us;
-
-    /* Block until timeout or an address/data error has been detected. */
-    while (((now_us - start_us) < timeout) &&
-            !nrf_twi_event_check(p_twi, NRF_TWI_EVENT_TXDSENT) &&
-            !nrf_twi_event_check(p_twi, NRF_TWI_EVENT_ERROR)) {
-        now_us = tick2us * lp_ticker_read();
-    }
-
-    /* Check error register and update return value if an address/data NACK was detected. */
-    uint32_t error = nrf_twi_errorsrc_get_and_clear(p_twi);
-
-    if ((error & NRF_TWI_ERROR_ADDRESS_NACK) || (error & NRF_TWI_ERROR_DATA_NACK)) {
-        result = 0; // NACK
-    } else if (now_us - start_us >= timeout) {
-        result = 2; // timeout
-    }
-
-    return result;
+    return 0;
 }
 
-/** Read one byte
- *
- *  @param obj The I2C object
- *  @param last Acknoledge
- *  @return The read byte
- */
 int i2c_byte_read(i2c_t *obj, int last)
 {
-    DEBUG_PRINTF("i2c_byte_read: %p %d\r\n", obj, last);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    int instance = config->instance;
-    int retval = I2C_ERROR_NO_SLAVE;
-
-    /* Due to hardware limitations, the stop condition must triggered through a short before
-     * reading the last byte.
-     */
-    if (last) {
-        nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], NRF_TWI_SHORT_BB_STOP_MASK);
-
-        /* Transaction will be complete after this call, reset state. */
-        config->state = NORDIC_TWI_STATE_IDLE;
-    }
-
-    /* Due to the way events are generated, if a byte is available it should be read directly
-     * but without resuming reading. Otherwise the TWI will read one byte too many.
-     */
-    if (nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY)) {
-        retval = nrf_twi_rxd_get(nordic_nrf5_twi_register[instance]);
-        nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY);
-    } else {
-
-        /* No data available, resume reception. */
-        nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_RESUME);
-
-        /* Wait ten byte duration for data */
-        uint32_t timeout = 10 * byte_timeout(config->frequency);
-        /* Setup timeout */
-        uint32_t start_us = tick2us * lp_ticker_read();
-        uint32_t now_us = start_us;
-
-        /* Block until timeout or data ready event has been signaled. */
-        while (((now_us - start_us) < timeout) &&
-                !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY))) {
-            now_us = tick2us * lp_ticker_read();
-        }
-
-        /* Retrieve data from buffer. */
-        if ((now_us - start_us) < timeout) {
-            retval = nrf_twi_rxd_get(nordic_nrf5_twi_register[instance]);
-            nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY);
-        }
-    }
-
-    return retval;
+    return 0;
 }
 
-/** Send STOP command
- *
- *  @param obj The I2C object
- */
 int i2c_stop(i2c_t *obj)
 {
-    DEBUG_PRINTF("i2c_stop: %p\r\n", obj);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    int instance = config->instance;
-
-    /* Set explicit stop signal. */
-    nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED);
-    nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_STOP);
-
-    /* Block until stop signal has been generated. */
-    uint32_t start_us = tick2us * lp_ticker_read();
-    uint32_t now_us = start_us;
-
-    while (((now_us - start_us) < MAXIMUM_TIMEOUT_US) &&
-            !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED))) {
-        now_us = tick2us * lp_ticker_read();
-    }
-
-    /* Reset state. */
-    config->state = NORDIC_TWI_STATE_IDLE;
-
     return 0;
 }
 
-/** Reset I2C peripheral. TODO: The action here. Most of the implementation sends stop()
- *
- *  @param obj The I2C object
- */
 void i2c_reset(i2c_t *obj)
 {
-    DEBUG_PRINTF("i2c_reset: %p\r\n", obj);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    /* Force reconfiguration to reset peripheral completely. */
-    config->update = true;
-    i2c_configure_twi_instance(obj);
+    uint8_t index = obj->instance.drv_inst_idx;
+    nrfx_twim_uninit(&obj->instance);
+    nrfx_twim_in_use[index] = false;
 }
 
-
-
-/***
- *      _____       _                  _________          _______
- *     |  __ \     (_)                |__   __\ \        / /_   _|
- *     | |  | |_ __ ___   _____ _ __     | |   \ \  /\  / /  | |
- *     | |  | | '__| \ \ / / _ \ '__|    | |    \ \/  \/ /   | |
- *     | |__| | |  | |\ V /  __/ |       | |     \  /\  /   _| |_
- *     |_____/|_|  |_| \_/ \___|_|       |_|      \/  \/   |_____|
- *
- *
- */
-
-/* Global array holding driver configuration for easy access. */
-static const nrfx_twi_t nordic_nrf5_instance[2] = {  NRFX_TWI_INSTANCE(0),  NRFX_TWI_INSTANCE(1) };
-
-#if DEVICE_I2CSLAVE
-static const nrfx_twis_t nordic_nrf5_twis_instance[2] = { NRFX_TWIS_INSTANCE(0), NRFX_TWIS_INSTANCE(1) };
-#endif
-
-/* Forward declare interrupt handler. */
-#if DEVICE_I2C_ASYNCH
-static void nordic_nrf5_twi_event_handler(nrfx_twi_evt_t const *p_event, void *p_context);
-#endif
-
-/**
- * @brief      Reconfigure driver.
- *
- *             If the peripheral is enabled, it will be disabled first. All
- *             registers are cleared to their default values unless replaced
- *             by new configuration.
- *
- *             If the object is the owner, the mode hasn't changed, and the
- *             force change flag is false, all settings are kept unchanged.
- *
- * @param      obj           The object
- * @param[in]  force_change  Set to true to force a reconfiguration.
- */
-static void i2c_configure_driver_instance(i2c_t *obj)
-{
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    int instance = config->instance;
-
-    /* Get pointer to object of the current owner of the peripheral. */
-    void *current_owner = object_owner_spi2c_get(instance);
-
-    /* Check if reconfiguration is actually necessary. */
-    if ((obj != current_owner) || (config->mode != NORDIC_I2C_MODE_DRIVER) || config->update) {
-
-        DEBUG_PRINTF("i2c_configure_driver_instance: %p %p\r\n", obj, current_owner);
-
-        /* Claim ownership of peripheral. */
-        object_owner_spi2c_set(instance, obj);
-
-        /* Set current mode. */
-        config->mode = NORDIC_I2C_MODE_DRIVER;
-
-        /* If the peripheral is already running, then disable it and use the driver API to uninitialize it.*/
-        if (nordic_nrf5_instance[instance].p_twi->ENABLE) {
-#if DEVICE_I2CSLAVE
-        /* If it was a slave, we should disable it with the appropriate driver */
-        if(config->was_slave) {
-            nrfx_twis_disable(&nordic_nrf5_twis_instance[instance]);
-            nrfx_twis_uninit(&nordic_nrf5_twis_instance[instance]);
-        }
-        else {
-            nrfx_twi_disable(&nordic_nrf5_instance[instance]);
-            nrfx_twi_uninit(&nordic_nrf5_instance[instance]);
-        }
-
-#else
-        nrfx_twi_disable(&nordic_nrf5_instance[instance]);
-        nrfx_twi_uninit(&nordic_nrf5_instance[instance]);
-#endif
-
-        }
-
-        /* Force resource release. This is necessary because mbed drivers don't
-         * deinitialize on object destruction.
-         */
-        NRFX_IRQ_DISABLE((nrfx_get_irq_number((void const *)nordic_nrf5_twi_register[instance])));
-
-#if DEVICE_I2CSLAVE
-        if(config->is_slave) {
-            /* Configure driver as slave with new settings. */
-            nrfx_twis_config_t twis_config = {
-                .addr = { (config->slave_addr >> 1), 0 },
-                .scl = config->scl,
-                .sda = config->sda,
-                .scl_pull = NRF_GPIO_PIN_NOPULL,
-                .sda_pull = NRF_GPIO_PIN_NOPULL,
-                .interrupt_priority = APP_IRQ_PRIORITY_LOWEST
-            };
-            /* Initialze driver in blocking mode. */
-            nrfx_twis_init(&nordic_nrf5_twis_instance[instance],
-                            &twis_config,
-                            NULL);
-
-            /* Enable peripheral (nrfx_twi_t and nrfx_twis_t are interchangeable). */
-            nrfx_twis_enable(&nordic_nrf5_twis_instance[instance]);
-        }
-        else {
-#endif
-
-            /* Configure driver with new settings. */
-            nrfx_twi_config_t twi_config = {
-                .scl = config->scl,
-                .sda = config->sda,
-                .frequency = config->frequency,
-                .interrupt_priority = APP_IRQ_PRIORITY_LOWEST,
-                .hold_bus_uninit = false
-            };
-
-#if DEVICE_I2C_ASYNCH
-            /* Set callback handler in asynchronous mode. */
-            if (config->handler) {
-
-                /* Initialze driver in non-blocking mode. */
-                nrfx_twi_init(&nordic_nrf5_instance[instance],
-                              &twi_config,
-                              nordic_nrf5_twi_event_handler,
-                              obj);
-            } else {
-
-                /* Initialze driver in blocking mode. */
-                nrfx_twi_init(&nordic_nrf5_instance[instance],
-                              &twi_config,
-                              NULL,
-                              NULL);
-            }
-#else
-            /* Initialze driver in blocking mode. */
-            nrfx_twi_init(&nordic_nrf5_instance[instance],
-                          &twi_config,
-                          NULL,
-                          NULL);
-#endif
-
-            /* Enable peripheral. */
-            nrfx_twi_enable(&nordic_nrf5_instance[instance]);
-#if DEVICE_I2CSLAVE
-        }
-#endif
-    }
-}
-
-/** Blocking reading data
- *
- *  @param obj     The I2C object
- *  @param address 7-bit address (last bit is 1)
- *  @param data    The buffer for receiving
- *  @param length  Number of bytes to read
- *  @param stop    Stop to be generated after the transfer is done
- *  @return Number of read bytes
- */
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    DEBUG_PRINTF("i2c_read: %p %d %p %d %d\r\n", obj, address, data, length, stop);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    int instance = config->instance;
-    int result = I2C_ERROR_NO_SLAVE;
-
-    /* Force peripheral configuration to avoid timing errors. */
-    config->update = true;
-    i2c_configure_driver_instance(obj);
-
-    /* Initialize transaction. */
-    ret_code_t retval = nrfx_twi_rx(&nordic_nrf5_instance[instance],
-                                    address >> 1,
-                                    (uint8_t *) data,
-                                    length);
-
-    /* Set return value on success. */
-    if (retval == NRF_SUCCESS) {
-        result = length;
-    }
-
-    DEBUG_PRINTF("result: %lu %d\r\n", retval, result);
-
-    return result;
-}
-
-/** Blocking sending data
- *
- *  @param obj     The I2C object
- *  @param address 7-bit address (last bit is 0)
- *  @param data    The buffer for sending
- *  @param length  Number of bytes to write
- *  @param stop    Stop to be generated after the transfer is done
- *  @return
- *      zero or non-zero - Number of written bytes
- *      negative - I2C_ERROR_XXX status
- */
-int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
-{
-    DEBUG_PRINTF("i2c_write: %p %d %p %d %d\r\n", obj, address, data, length, stop);
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    int instance = config->instance;
-    int result = I2C_ERROR_NO_SLAVE;
-
-    /* Force peripheral configuration to avoid timing errors. */
-    config->update = true;
-    i2c_configure_driver_instance(obj);
-
-    /* Initialize transaction. */
-    ret_code_t retval = nrfx_twi_tx(&nordic_nrf5_instance[instance],
-                                    address >> 1,
-                                    (const uint8_t *) data,
-                                    length,
-                                    !stop);
-
-    /* Set return value on success. */
-    if (retval == NRF_SUCCESS) {
-        result = length;
-    }
-
-    DEBUG_PRINTF("result: %lu %d\r\n", retval, result);
-
-    return result;
-}
-
-
-#if DEVICE_I2C_ASYNCH
-
-/***
- *                                               _____ _____
- *         /\                              /\   |  __ \_   _|
- *        /  \   ___ _   _ _ __   ___     /  \  | |__) || |
- *       / /\ \ / __| | | | '_ \ / __|   / /\ \ |  ___/ | |
- *      / ____ \\__ \ |_| | | | | (__   / ____ \| |    _| |_
- *     /_/    \_\___/\__, |_| |_|\___| /_/    \_\_|   |_____|
- *                    __/ |
- *                   |___/
- */
-
-/* Callback function for driver calls. This is called from ISR context. */
-static void nordic_nrf5_twi_event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
-{
-    // Only safe to use with mbed-printf.
-    //DEBUG_PRINTF("nordic_nrf5_twi_event_handler: %d %p\r\n", p_event->type, p_context);
-
-    i2c_t *obj = (i2c_t *) p_context;
-    struct i2c_s *config = &obj->i2c;
-
-    /* Translate event type from NRF driver values to mbed HAL values. */
-    switch (p_event->type) {
-        /* Transfer completed event. */
-        case NRFX_TWI_EVT_DONE:
-            config->event = I2C_EVENT_TRANSFER_COMPLETE;
-            break;
-
-        /* Error event: NACK received after sending the address. */
-        case NRFX_TWI_EVT_ADDRESS_NACK:
-            config->event = I2C_EVENT_ERROR_NO_SLAVE;
-            break;
-
-        /* Error event: NACK received after sending a data byte. */
-        case NRFX_TWI_EVT_DATA_NACK:
-            config->event = I2C_EVENT_TRANSFER_EARLY_NACK;
-            break;
-
-        default:
-            config->event = I2C_EVENT_ERROR;
-            break;
-    }
-
-    /* If event matches event mask and event handler is set, signal event. */
-    if ((config->event & config->mask) && config->handler) {
-
-        /* Cast handler to function pointer. */
-        void (*callback)(void) = (void (*)(void)) config->handler;
-
-        /* Reset handler and force reconfiguration. */
-        config->handler = 0;
-        config->update = true;
-
-        /* Signal callback handler. */
-        callback();
-    }
-}
-
-/** Start I2C asynchronous transfer
- *
- *  @param obj       The I2C object
- *  @param tx        The transmit buffer
- *  @param tx_length The number of bytes to transmit
- *  @param rx        The receive buffer
- *  @param rx_length The number of bytes to receive
- *  @param address   The address to be set - 7bit or 9bit
- *  @param stop      If true, stop will be generated after the transfer is done
- *  @param handler   The I2C IRQ handler to be set
- *  @param event     Event mask for the transfer. See \ref hal_I2CEvents
- *  @param hint      DMA hint usage
- */
-void i2c_transfer_asynch(i2c_t *obj,
-                         const void *tx,
-                         size_t tx_length,
-                         void *rx,
-                         size_t rx_length,
-                         uint32_t address,
-                         uint32_t stop,
-                         uint32_t handler,
-                         uint32_t mask,
-                         DMAUsage hint)
-{
-    DEBUG_PRINTF("i2c_transfer_asynch\r\n");
-
-    /* TWI only supports 7 bit addresses. */
-    MBED_ASSERT(address < 0xFF);
-
-    struct i2c_s *config = &obj->i2c;
-    int instance = config->instance;
-
-    /* Save event handler and event mask in global variables so they can be called from interrupt handler. */
-    config->handler = handler;
-    config->mask = mask;
-
-    /* Clear event flag. */
-    config->event = 0;
-
-    /* Configure peripheral. */
-    config->update = true;
-    i2c_configure_driver_instance(obj);
-
-    /* Configure TWI transfer. */
-    const nrfx_twi_xfer_desc_t twi_config = NRFX_TWI_XFER_DESC_TXRX(address >> 1,
-                                                                    (uint8_t *) tx,
-                                                                    tx_length,
-                                                                    rx,
-                                                                    rx_length);
-
-    uint32_t flags = (stop) ? 0 : NRFX_TWI_FLAG_TX_NO_STOP;
-
-    /* Initiate TWI transfer using NRF driver. */
-    ret_code_t result = nrfx_twi_xfer(&nordic_nrf5_instance[instance],
-                                      &twi_config,
-                                      flags);
-
-    /* Signal error if event mask matches and event handler is set. */
-    if ((result != NRF_SUCCESS) && (mask & I2C_EVENT_ERROR) && handler) {
-
-        /* Store event value so it can be read back. */
-        config->event = I2C_EVENT_ERROR;
-
-        /* Cast handler to function pointer. */
-        void (*callback)(void) = (void (*)(void)) handler;
-
-        /* Reset handler and force reconfiguration. */
-        config->handler = 0;
-        config->update = true;
-
-        /* Signal callback handler. */
-        callback();
-    }
-}
-
-/** The asynchronous IRQ handler
- *
- *  @param obj The I2C object which holds the transfer information
- *  @return Event flags if a transfer termination condition was met, otherwise return 0.
- */
-uint32_t i2c_irq_handler_asynch(i2c_t *obj)
-{
-    DEBUG_PRINTF("i2c_irq_handler_asynch\r\n");
-
-    /* Return latest event. */
-    return obj->i2c.event;
-}
-
-/** Attempts to determine if the I2C peripheral is already in use
- *
- *  @param obj The I2C object
- *  @return Non-zero if the I2C module is active or zero if it is not
- */
-uint8_t i2c_active(i2c_t *obj)
-{
-    DEBUG_PRINTF("i2c_active\r\n");
-
-    /* Query NRF driver if transaction is in progress. */
-    return nrfx_twi_is_busy(&nordic_nrf5_instance[obj->i2c.instance]);
-}
-
-/** Abort asynchronous transfer
- *
- *  This function does not perform any check - that should happen in upper layers.
- *  @param obj The I2C object
- */
-void i2c_abort_asynch(i2c_t *obj)
-{
-    DEBUG_PRINTF("i2c_abort_asynch\r\n");
-
-    /* Reconfiguration will disable and enable the TWI module. */
-    obj->i2c.update = true;
-    i2c_configure_driver_instance(obj);
-}
-
-#endif // DEVICE_I2C_ASYNCH
-
-#if DEVICE_I2CSLAVE
-
-/***
- *      _____ ___   _____    _____ _
- *     |_   _|__ \ / ____|  / ____| |
- *       | |    ) | |      | (___ | | __ ___   _____
- *       | |   / /| |       \___ \| |/ _` \ \ / / _ \
- *      _| |_ / /_| |____   ____) | | (_| |\ V /  __/
- *     |_____|____|\_____| |_____/|_|\__,_| \_/ \___|
- *
- *
- */
-
-/** Configure I2C as slave or master.
- *  @param obj The I2C object
- *  @param enable_slave Enable i2c hardware so you can receive events with ::i2c_slave_receive
- *  @return non-zero if a value is available
- */
-void i2c_slave_mode(i2c_t *obj, int enable_slave)
-{
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    /* Reconfigure this instance as an I2C slave */
-
-    /* Not configured yet, so this instance is and was a slave */
-    if(config->state == NRFX_DRV_STATE_UNINITIALIZED) {
-    		config->was_slave = enable_slave;
-    } else {
-        config->was_slave = config->is_slave;
-    }
-    config->is_slave = enable_slave;
-    config->update = true;
-
-    i2c_configure_driver_instance(obj);
-
-    DEBUG_PRINTF("i2c_slave_mode\r\n");
-}
-
-/** Check to see if the I2C slave has been addressed.
- *  @param obj The I2C object
- *  @return The status - 1 - read addresses, 2 - write to all slaves,
- *         3 write addressed, 0 - the slave has not been addressed
- */
-int i2c_slave_receive(i2c_t *obj)
-{
-    DEBUG_PRINTF("i2c_slave_receive\r\n");
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    const nrfx_twis_t* twis_instance = &nordic_nrf5_twis_instance[config->instance];
-
-    if(nrfx_twis_is_waiting_rx_buff(twis_instance)) {
-    		return 3;
-    }
-
-    if(nrfx_twis_is_waiting_tx_buff(twis_instance)) {
-    		return 1;
-    }
-
     return 0;
 }
 
-/** Configure I2C as slave or master.
- *  @param obj The I2C object
- *  @param data    The buffer for receiving
- *  @param length  Number of bytes to read
- *  @return non-zero if a value is available
- */
-int i2c_slave_read(i2c_t *obj, char *data, int length)
+int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 {
-    DEBUG_PRINTF("i2c_slave_read\r\n");
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    const nrfx_twis_t* twis_instance = &nordic_nrf5_twis_instance[config->instance];
-
-    /* Wait until the master is trying to write data */
-    while(!nrfx_twis_is_waiting_rx_buff(twis_instance)) { }
-
-    /* Master is attempting to write, now we prepare the rx buffer */
-    nrfx_twis_rx_prepare(twis_instance,
-    		data,
-		length);
-
-    /* Wait until the transaction is over */
-    while(nrfx_twis_is_pending_rx(twis_instance)) { }
-
-    return nrfx_twis_rx_amount(twis_instance);
+    while(!nrfx_twim_is_busy(&obj->instance));
+    nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_TX(address, (uint8_t *)data, length);
+    int error = nrfx_twim_xfer(&obj->instance, &descriptor, stop ? 0 : NRFX_TWIM_FLAG_TX_NO_STOP);
+    return error ? error : length;
 }
-
-/** Configure I2C as slave or master.
- *  @param obj The I2C object
- *  @param data    The buffer for sending
- *  @param length  Number of bytes to write
- *  @return non-zero if a value is available
- */
-int i2c_slave_write(i2c_t *obj, const char *data, int length)
-{
-    DEBUG_PRINTF("i2c_slave_write\r\n");
-
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    const nrfx_twis_t* twis_instance = &nordic_nrf5_twis_instance[config->instance];
-
-    /* Wait until the master is trying to read data */
-    while(!nrfx_twis_is_waiting_tx_buff(twis_instance)) { }
-
-    /* Master is attempting to read, now we prepare the tx buffer */
-    nrfx_twis_tx_prepare(twis_instance,
-    		data,
-		length);
-
-    /* Wait until the transaction is over */
-    while(nrfx_twis_is_pending_tx(twis_instance)) { }
-
-    return nrfx_twis_tx_amount(twis_instance);
-}
-
-/** Configure I2C address.
- *  @param obj     The I2C object
- *  @param idx     Currently not used
- *  @param address The address to be set
- *  @param mask    Currently not used
- */
-void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
-{
-#if DEVICE_I2C_ASYNCH
-    struct i2c_s *config = &obj->i2c;
-#else
-    struct i2c_s *config = obj;
-#endif
-
-    /* Reconfigure this instance as an I2C slave with given address */
-    config->update = true;
-    config->slave_addr = (uint8_t) address;
-
-    i2c_configure_driver_instance(obj);
-
-    DEBUG_PRINTF("i2c_slave_address\r\n");
-}
-
-#endif // DEVICE_I2CSLAVE
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
@@ -112,6 +112,11 @@ struct pwmout_s {
 struct i2c_s {
     nrfx_twim_t instance;
     nrfx_twim_config_t config;
+    int transfer_result;
+    volatile bool transfer_complete;
+    int address;
+    char buffer[256];
+    uint16_t length;
 };
 
 struct analogin_s {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
@@ -48,7 +48,7 @@
 #elif DEVICE_SPI
 #include "nrfx_spi.h"
 #endif
-#include "nrf_twim.h"
+#include "nrfx_twim.h"
 
 #include "nrf_pwm.h"
 
@@ -110,25 +110,8 @@ struct pwmout_s {
 };
 
 struct i2c_s {
-    int instance;
-    PinName sda;
-    PinName scl;
-    nrf_twim_frequency_t frequency;
-    int state;
-    int mode;
-    bool update;
-
-#if DEVICE_I2C_ASYNCH
-    uint32_t handler;
-    uint32_t mask;
-    uint32_t event;
-#endif
-
-#if DEVICE_I2CSLAVE
-    bool was_slave;
-    bool is_slave;
-    uint8_t slave_addr;
-#endif
+    nrfx_twim_t instance;
+    nrfx_twim_config_t config;
 };
 
 struct analogin_s {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/serial_api.c
@@ -73,7 +73,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
 
     for (uint8_t index = 0; index < UARTE_COUNT; ++index) {
         if (!nrfx_uarte_in_use[index]) {
-            nrfx_uarte_in_use[index] = true;
             switch (index) {
 #if NRFX_CHECK(NRFX_UARTE0_ENABLED)
                 case 0: {
@@ -104,8 +103,9 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
                 }
 #endif
                 default:
-                    break;
+                    continue;
             }
+            nrfx_uarte_in_use[index] = true;
             break;
         }
     }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_17_1/modules/CMakeLists.txt
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_17_1/modules/CMakeLists.txt
@@ -13,7 +13,6 @@ target_include_directories(mbed-core
         nrfx/helpers
         nrfx/mdk
         nrfx/soc
-        nrfx/templates
 )
 
 target_sources(mbed-core
@@ -43,9 +42,9 @@ target_sources(mbed-core
         nrfx/drivers/src/nrfx_systick.c
         nrfx/drivers/src/nrfx_temp.c
         nrfx/drivers/src/nrfx_timer.c
-        nrfx/drivers/src/nrfx_twi.c
         nrfx/drivers/src/nrfx_twi_twim.c
         nrfx/drivers/src/nrfx_twi.c
+        nrfx/drivers/src/nrfx_twim.c
         nrfx/drivers/src/nrfx_twis.c
         nrfx/drivers/src/nrfx_uart.c
         nrfx/drivers/src/nrfx_uarte.c

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_17_1/modules/nrfx/templates/nrfx_config_nrf5340_application.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_17_1/modules/nrfx/templates/nrfx_config_nrf5340_application.h
@@ -1644,20 +1644,20 @@
 // <e> NRFX_TWIM_ENABLED - nrfx_twim - TWIM peripheral driver.
 //==========================================================
 #ifndef NRFX_TWIM_ENABLED
-#define NRFX_TWIM_ENABLED 0
+#define NRFX_TWIM_ENABLED 1
 #endif
 // <q> NRFX_TWIM0_ENABLED  - Enables TWIM0 instance.
 
 
 #ifndef NRFX_TWIM0_ENABLED
-#define NRFX_TWIM0_ENABLED 0
+#define NRFX_TWIM0_ENABLED 1
 #endif
 
 // <q> NRFX_TWIM1_ENABLED  - Enables TWIM1 instance.
 
 
 #ifndef NRFX_TWIM1_ENABLED
-#define NRFX_TWIM1_ENABLED 0
+#define NRFX_TWIM1_ENABLED 1
 #endif
 
 // <q> NRFX_TWIM2_ENABLED  - Enables TWIM2 instance.


### PR DESCRIPTION
* Tested with I2C EEPROM mounted on nRF5340 DK kit and by using I2CEEBlockDevice driver in Mbed
* Single byte write is emulated as the TWIM driver only supports complete writes
* Moved nRF5340 config to board config folder
* Minor UART fix when using last indexes