### PR TITLE
Added nRF5340 ADC support

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/PeripheralPinMaps.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/PeripheralPinMaps.h
@@ -19,28 +19,18 @@
 #define MBED_PERIPHERALPINMAPS_H
 
 #include <mstd_cstddef>
-
-typedef enum {
-    NRF_SAADC_CHANNEL_0 = 0,
-    NRF_SAADC_CHANNEL_1 = 1,
-    NRF_SAADC_CHANNEL_2 = 2,
-    NRF_SAADC_CHANNEL_3 = 3,
-    NRF_SAADC_CHANNEL_4 = 4,
-    NRF_SAADC_CHANNEL_5 = 5,
-    NRF_SAADC_CHANNEL_6 = 6,
-    NRF_SAADC_CHANNEL_7 = 7,
-} nrf_saadc_channel_t;
+#include <nrf_saadc.h>
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
 #if DEVICE_ANALOGIN
 MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
-    { P0_4,  ADC0_0, NRF_SAADC_CHANNEL_0 },
-    { P0_5,  ADC0_0, NRF_SAADC_CHANNEL_1 },
-    { P0_6,  ADC0_0, NRF_SAADC_CHANNEL_2 },
-    { P0_7,  ADC0_0, NRF_SAADC_CHANNEL_3 },
-    { P0_25, ADC0_0, NRF_SAADC_CHANNEL_4 },
-    { P0_26, ADC0_0, NRF_SAADC_CHANNEL_5 },
+    { P0_4,  ADC0_0, NRF_SAADC_INPUT_AIN0 },
+    { P0_5,  ADC0_0, NRF_SAADC_INPUT_AIN1 },
+    { P0_6,  ADC0_0, NRF_SAADC_INPUT_AIN2 },
+    { P0_7,  ADC0_0, NRF_SAADC_INPUT_AIN3 },
+    { P0_25, ADC0_0, NRF_SAADC_INPUT_AIN4 },
+    { P0_26, ADC0_0, NRF_SAADC_INPUT_AIN5 },
     { NC,    NC,     NC                  }
 };
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/PeripheralPinMaps.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/PeripheralPinMaps.h
@@ -35,15 +35,13 @@ typedef enum {
 /* The third "function" value is used to select the correct ADC channel */
 #if DEVICE_ANALOGIN
 MSTD_CONSTEXPR_OBJ_11 PinMap PinMap_ADC[] = {
-    { p2,  ADC0_0, NRF_SAADC_CHANNEL_0 },
-    { p3,  ADC0_0, NRF_SAADC_CHANNEL_1 },
-    { p4,  ADC0_0, NRF_SAADC_CHANNEL_2 },
-    { p5,  ADC0_0, NRF_SAADC_CHANNEL_3 },
-    { p28, ADC0_0, NRF_SAADC_CHANNEL_4 },
-    { p29, ADC0_0, NRF_SAADC_CHANNEL_5 },
-    { p30, ADC0_0, NRF_SAADC_CHANNEL_6 },
-    { p31, ADC0_0, NRF_SAADC_CHANNEL_7 },
-    { NC,  NC,     NC                  }
+    { P0_4,  ADC0_0, NRF_SAADC_CHANNEL_0 },
+    { P0_5,  ADC0_0, NRF_SAADC_CHANNEL_1 },
+    { P0_6,  ADC0_0, NRF_SAADC_CHANNEL_2 },
+    { P0_7,  ADC0_0, NRF_SAADC_CHANNEL_3 },
+    { P0_25, ADC0_0, NRF_SAADC_CHANNEL_4 },
+    { P0_26, ADC0_0, NRF_SAADC_CHANNEL_5 },
+    { NC,    NC,     NC                  }
 };
 #endif
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config_nrf5340_application.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/TARGET_MCU_NRF5340_APPLICATION/config/nrfx_config_nrf5340_application.h
@@ -1253,7 +1253,7 @@
 // <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver.
 //==========================================================
 #ifndef NRFX_SAADC_ENABLED
-#define NRFX_SAADC_ENABLED 0
+#define NRFX_SAADC_ENABLED 1
 #endif
 
 // <o> NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority.

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
@@ -21,14 +21,10 @@
 
 #include "pinmap.h"
 #include "PeripheralPins.h"
-
 #include "nrfx_saadc.h"
-#include "sdk_config.h"
 
 #define ADC_12BIT_RANGE 0x0FFF
 #define ADC_16BIT_RANGE 0xFFFF
-
-int nrfx_result = 0;
 
 #if STATIC_PINMAP_READY
 #define ANALOGIN_INIT_DIRECT analogin_init_direct
@@ -38,11 +34,11 @@ void analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
 static void _analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
 #endif
 {
-    ret_code_t result;
-    MBED_ASSERT(obj);
-
-    /* Only initialize SAADC on first pin. */
+    nrfx_err_t result;
     static bool first_init = true;
+
+    MBED_ASSERT(obj);
+    MBED_ASSERT(pinmap->pin != NC);
 
     if (first_init) {
         result = nrfx_saadc_init(NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY);
@@ -50,74 +46,53 @@ static void _analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
         first_init = false;
     }
 
-    /* Use pinmap function to get associated channel. */
-    uint32_t channel = (uint32_t) pinmap->function;
-    MBED_ASSERT(channel != (uint32_t) NC);
+    /* Only use a single channel (index 0) for all conversions */
+    nrfx_saadc_channel_t channel = NRFX_SAADC_DEFAULT_CHANNEL_SE(pinmap->function, 0);
 
-    nrfx_saadc_channel_t channel_config = NRFX_SAADC_DEFAULT_CHANNEL_SE(channel, 0);
-    result = nrfx_saadc_channel_config(&channel_config);
-    MBED_ASSERT(result == NRFX_SUCCESS);
+    /* The 1/4 gain and VDD/4 makes the reference voltage VDD */
+    channel.channel_config.gain = NRF_SAADC_GAIN1_4,
+    channel.channel_config.reference = NRF_SAADC_REFERENCE_VDD4;
 
-    result = nrfx_saadc_simple_mode_set()
+    result = nrfx_saadc_channel_config(&channel);
     MBED_ASSERT(result == NRFX_SUCCESS);
 }
 
 void analogin_init(analogin_t *obj, PinName pin)
 {
-    int peripheral = (int)pinmap_peripheral(pin, PinMap_ADC);
-    int function = (int)pinmap_find_function(pin, PinMap_ADC);
-
-    const PinMap static_pinmap = {pin, peripheral, function};
-
+    const PinMap static_pinmap = {pin, pinmap_peripheral(pin, PinMap_ADC), pinmap_find_function(pin, PinMap_ADC)};
     ANALOGIN_INIT_DIRECT(obj, &static_pinmap);
 }
 
-/** Read the input voltage, represented as a float in the range [0.0, 1.0]
- *
- * @param obj The analogin object
- * @return A floating value representing the current input voltage
- */
 uint16_t analogin_read_u16(analogin_t *obj)
 {
-    MBED_ASSERT(obj);
+    nrfx_err_t result;
+    uint16_t value = 0;
+    nrf_saadc_value_t raw_value = 0;
 
-    /* Default return value is 0. */
-    uint16_t retval = 0;
+    /* Use simple mode (single sample conversion) using channel index 0 in blocking mode */
+    result = nrfx_saadc_simple_mode_set((1 << 0), NRF_SAADC_RESOLUTION_12BIT, NRF_SAADC_OVERSAMPLE_DISABLED, NULL);
+    MBED_ASSERT(result == NRFX_SUCCESS);
 
-    /* Read single channel, blocking. */
-    nrf_saadc_value_t value = { 0 };
-    ret_code_t result = nrfx_saadc_buffer_set(&value, 1);
-    nrfx_result = result;
+    result = nrfx_saadc_buffer_set(&raw_value, 1);
     MBED_ASSERT(result == NRFX_SUCCESS);
 
     result = nrfx_saadc_mode_trigger();
-    nrfx_result = result;
     MBED_ASSERT(result == NRFX_SUCCESS);
 
-    /* nrf_saadc_value_t is a signed integer. Only take the absolute value. */
-    if (value > 0) {
-        /* Normalize 12 bit ADC value to 16 bit Mbed ADC range. */
-        uint32_t normalized = value;
-        retval = (normalized * ADC_16BIT_RANGE) / ADC_12BIT_RANGE;
+    if (raw_value > 0) {
+        /* Convert the value from 12 to 16-bit as used by Mbed */
+        value = ((uint32_t)raw_value * ADC_16BIT_RANGE) / ADC_12BIT_RANGE;
     }
 
-    return retval;
+    return value;
 }
 
-/** Read the value from analogin pin, represented as an unsigned 16bit value
- *
- * @param obj The analogin object
- * @return An unsigned 16bit value representing the current input voltage
- */
 float analogin_read(analogin_t *obj)
 {
     MBED_ASSERT(obj);
 
-    /* Read 16 bit ADC value (using Mbed API) and convert to [0;1] range float. */
-    uint16_t value = analogin_read_u16(obj);
-    float result = ((float) value / (float) ADC_16BIT_RANGE);
-
-    return result;
+    /* Read 16 bit ADC value (using Mbed API) and convert to [0;1] range float */
+    return ((float)analogin_read_u16(obj) / (float)ADC_16BIT_RANGE);
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
@@ -23,28 +23,13 @@
 #include "PeripheralPins.h"
 
 #include "nrfx_saadc.h"
-#include "nrfx_errors.h"
 #include "sdk_config.h"
 
 #define ADC_12BIT_RANGE 0x0FFF
 #define ADC_16BIT_RANGE 0xFFFF
 
-/* Unused event handler but driver requires one. */
-static void analog_in_event_handler(nrfx_saadc_evt_t const *p_event)
-{
-    (void) p_event;
+int nrfx_result = 0;
 
-}
-
-/* Interrupt handler implemented in nrfx_saadc.c. */
-void SAADC_IRQHandler(void);
-
-/** Initialize the analogin peripheral
- *
- * Configures the pin used by analogin.
- * @param obj The analogin object to initialize
- * @param pin The analogin pin name
- */
 #if STATIC_PINMAP_READY
 #define ANALOGIN_INIT_DIRECT analogin_init_direct
 void analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
@@ -53,63 +38,28 @@ void analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
 static void _analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
 #endif
 {
+    ret_code_t result;
     MBED_ASSERT(obj);
 
     /* Only initialize SAADC on first pin. */
     static bool first_init = true;
 
     if (first_init) {
-
-        first_init = false;
-
-        /* Use configuration from sdk_config.h.
-         * Default is:
-         *  - 12 bit.
-         *  - No oversampling.
-         *  - Priority 7 (lowest).
-         *  - No low power mode.
-         */
-        nrf_saadc_config_t adc_config = {
-            .resolution         = (nrf_saadc_resolution_t)SAADC_CONFIG_RESOLUTION,
-            .oversample         = (nrf_saadc_oversample_t)SAADC_CONFIG_OVERSAMPLE,
-            .interrupt_priority = SAADC_CONFIG_IRQ_PRIORITY,
-            .low_power_mode     = SAADC_CONFIG_LP_MODE
-        };
-
-        [[maybe_unused]] ret_code_t result = nrfx_saadc_init(&adc_config, analog_in_event_handler);
+        result = nrfx_saadc_init(NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY);
         MBED_ASSERT(result == NRFX_SUCCESS);
-
-        /* Register interrupt handler in vector table. */
-        NVIC_SetVector(SAADC_IRQn, (uint32_t)SAADC_IRQHandler);
+        first_init = false;
     }
 
     /* Use pinmap function to get associated channel. */
     uint32_t channel = (uint32_t) pinmap->function;
     MBED_ASSERT(channel != (uint32_t) NC);
 
-    /* Account for an off-by-one in Channel definition and Input definition. */
-    nrf_saadc_input_t input = channel + 1;
-
-    /* Configure channel and pin:
-     *  - the 1/4 gain and VDD/4 makes the reference voltage VDD.
-     */
-    nrf_saadc_channel_config_t channel_config = {
-        .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
-        .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
-        .gain       = NRF_SAADC_GAIN1_4,
-        .reference  = NRF_SAADC_REFERENCE_VDD4,
-        .acq_time   = NRF_SAADC_ACQTIME_10US,
-        .mode       = NRF_SAADC_MODE_SINGLE_ENDED,
-        .burst      = NRF_SAADC_BURST_DISABLED,
-        .pin_p      = input,
-        .pin_n      = NRF_SAADC_INPUT_DISABLED
-    };
-
-    [[maybe_unused]] ret_code_t result = nrfx_saadc_channel_init(channel, &channel_config);
+    nrfx_saadc_channel_t channel_config = NRFX_SAADC_DEFAULT_CHANNEL_SE(channel, 0);
+    result = nrfx_saadc_channel_config(&channel_config);
     MBED_ASSERT(result == NRFX_SUCCESS);
 
-    /* Store channel in ADC object. */
-    obj->channel = channel;
+    result = nrfx_saadc_simple_mode_set()
+    MBED_ASSERT(result == NRFX_SUCCESS);
 }
 
 void analogin_init(analogin_t *obj, PinName pin)
@@ -136,11 +86,16 @@ uint16_t analogin_read_u16(analogin_t *obj)
 
     /* Read single channel, blocking. */
     nrf_saadc_value_t value = { 0 };
-    ret_code_t result = nrfx_saadc_sample_convert(obj->channel, &value);
+    ret_code_t result = nrfx_saadc_buffer_set(&value, 1);
+    nrfx_result = result;
+    MBED_ASSERT(result == NRFX_SUCCESS);
+
+    result = nrfx_saadc_mode_trigger();
+    nrfx_result = result;
+    MBED_ASSERT(result == NRFX_SUCCESS);
 
     /* nrf_saadc_value_t is a signed integer. Only take the absolute value. */
-    if ((result == NRFX_SUCCESS) && (value > 0)) {
-
+    if (value > 0) {
         /* Normalize 12 bit ADC value to 16 bit Mbed ADC range. */
         uint32_t normalized = value;
         retval = (normalized * ADC_16BIT_RANGE) / ADC_12BIT_RANGE;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
@@ -120,7 +120,6 @@ struct i2c_s {
 };
 
 struct analogin_s {
-    uint8_t channel;
 };
 
 struct gpio_irq_s {


### PR DESCRIPTION
Tested using the below snippets with A0 set to VDD and A1 set to GND:

```cpp
AnalogIn analog0(A0);
printf("Value is 0x%02x (%f)\n", analog0.read_u16(), analog0.read());

AnalogIn analog1(A1);
printf("Value is 0x%02x (%f)\n", analog1.read_u16(), analog1.read());
```

Output:

```
Value is 0xffff (1.00)
Value is 0x00 (0.00)
```