### PR TITLE
Add default CThunk constructor

### DIFF
--- a/platform/include/platform/CThunk.h
+++ b/platform/include/platform/CThunk.h
@@ -47,6 +47,8 @@ public:
     typedef void (T::*CCallbackSimple)(void);
     typedef void (T::*CCallback)(void *context);
 
+    CThunk() = default;
+
     inline CThunk(T *instance)
     {
         init(instance, NULL, NULL);


### PR DESCRIPTION
Needed for I2C