### PR TITLE
Remove dead code

### DIFF
--- a/events/include/events/EventQueue.h
+++ b/events/include/events/EventQueue.h
@@ -761,10 +761,7 @@ public:
 
         F *e = new (p) F(std::move(f));
         equeue_event_dtor(e, &EventQueue::function_dtor<F>);
-        int id = equeue_post(&_equeue, &EventQueue::function_call<F>, e);
-        if (!id)
-            queue_full(QUEUE_FULL_CALL, sizeof(F));
-        return id;
+        return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
 
@@ -841,10 +838,7 @@ public:
         F *e = new (p) F(std::move(f));
         equeue_event_delay(e, ms.count());
         equeue_event_dtor(e, &EventQueue::function_dtor<F>);
-        int id = equeue_post(&_equeue, &EventQueue::function_call<F>, e);
-        if (!id)
-            queue_full(QUEUE_FULL_CALL_IN, sizeof(F));
-        return id;
+        return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
     /** Calls an event on the queue after a specified delay
@@ -999,10 +993,7 @@ public:
         equeue_event_delay(e, ms.count());
         equeue_event_period(e, ms.count());
         equeue_event_dtor(e, &EventQueue::function_dtor<F>);
-        int id = equeue_post(&_equeue, &EventQueue::function_call<F>, e);
-        if (!id)
-            queue_full(QUEUE_FULL_CALL_EVERY, sizeof(F));
-        return id;
+        return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
     /** Calls an event on the queue periodically


### PR DESCRIPTION
We patched in this logging point earlier, but once the event is created,
it will be accepted by the event queue, and thus it must have an ID, so
this cannot fail.
No need to have this customization point.
