### PR TITLE
Clear idle interrupt flag on STM32F4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -783,7 +783,7 @@ static void uart1_irq_idle(void)
 
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE) != RESET) {
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_IDLE);
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear IDLE flag
                 serial_idle_callback();
             }
         }


### PR DESCRIPTION
Reference Manual on how to clear UART IDLE flag
![image](https://user-images.githubusercontent.com/4113918/171380887-1cb63222-3aa8-4b92-a60f-5df61ca3cc9d.png)
