### PR TITLE
Clean up of UART DMA RX/TX

### DIFF
--- a/hal/include/hal/serial_api.h
+++ b/hal/include/hal/serial_api.h
@@ -294,7 +294,7 @@ int  serial_readable(serial_t *obj);
  * @param obj The serial object
  * @return Non-zero value if a character can be written, 0 otherwise.
  */
-int  serial_writable(serial_t *obj);
+int  serial_writable(const serial_t *obj);
 
 /** Clear the serial peripheral
  *
@@ -451,12 +451,12 @@ void serial_tx_abort_asynch(serial_t *obj);
  */
 void serial_rx_abort_asynch(serial_t *obj);
 
-void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buffer, size_t buffer_size, void(*DmaCompleteCallback)(uint32_t), uint32_t id);
-void serial_tx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_tx, void(*DmaCompleteCallback)(uint32_t), uint32_t id);
+void serial_rx_dma_init(serial_t *obj, uint8_t* buffer, size_t buffer_size, void(*DmaCompleteCallback)(uint32_t), uint32_t id);
+void serial_tx_dma_init(serial_t *obj);
 void serial_rx_dma_free(serial_t *obj);
 void serial_tx_dma_free(serial_t *obj);
-size_t serial_tx_dma(serial_t *obj, uint8_t* buffer, size_t buffer_size);
-size_t serial_get_dma_rx_position(serial_t *obj);
+size_t serial_tx_dma(serial_t *obj, const uint8_t* buffer, size_t buffer_size);
+size_t serial_get_dma_rx_position(const serial_t *obj);
 void serial_idle_callback(void);
 /**@}*/
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/serial_api.c
@@ -215,7 +215,7 @@ int serial_readable(serial_t *obj) {
     return obj->rx_buffer_primary_set || obj->rx_buffer_secondary_set;
 }
 
-int serial_writable(serial_t *obj) {
+int serial_writable(const serial_t *obj) {
     return !nrfx_uarte_tx_in_progress(&obj->instance);
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -46,6 +46,8 @@
 
 uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
+DMA_HandleTypeDef dma_handlers_rx;
+DMA_HandleTypeDef dma_handlers_tx;
 
 static uart_irq_handler irq_handler;
 
@@ -726,16 +728,14 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-UART_HandleTypeDef * dmauart;
-
 void DMA2_Stream2_IRQHandler(void)
 {
-    HAL_DMA_IRQHandler(dmauart->hdmarx);
+    HAL_DMA_IRQHandler(&dma_handlers_rx);
 }
 
 void DMA2_Stream7_IRQHandler(void)
 {
-    HAL_DMA_IRQHandler(dmauart->hdmatx);
+    HAL_DMA_IRQHandler(&dma_handlers_tx);
 }
 
 /**
@@ -751,20 +751,10 @@ typedef void(*DmaCompleteCallback)(uint32_t);
 DmaCompleteCallback callback_dma_rx;
 uint32_t callback_id_dma_rx;
 
-DmaCompleteCallback callback_dma_tx;
-uint32_t callback_id_dma_tx;
-
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef* UartHandle)
 {
     /* Set transmission flag: transfer complete*/
     serial_idle_callback();
-}
-
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef* UartHandle)
-{
-    if (callback_dma_tx) {
-        callback_dma_tx(callback_id_dma_tx);
-    }
 }
 
 void serial_idle_callback(void)
@@ -797,28 +787,28 @@ static void uart1_irq_idle(void)
     }
 }
 
-void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buffer, size_t buffer_size, DmaCompleteCallback callback, uint32_t id)
+void serial_rx_dma_init(serial_t *obj, uint8_t* buffer, size_t buffer_size, DmaCompleteCallback callback, uint32_t id)
 {
     __HAL_RCC_DMA2_CLK_ENABLE();
     /* Configure the DMA handler for reception process */
-    hdma_rx->Instance = DMA2_Stream2;
-    hdma_rx->Init.Channel = DMA_CHANNEL_4;
-    hdma_rx->Init.Direction = DMA_PERIPH_TO_MEMORY;
-    hdma_rx->Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_rx->Init.MemInc = DMA_MINC_ENABLE;
-    hdma_rx->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_rx->Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_rx->Init.Mode = DMA_CIRCULAR;
-    hdma_rx->Init.Priority = DMA_PRIORITY_LOW;
-    hdma_rx->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
+    dma_handlers_rx.Instance = DMA2_Stream2;
+    dma_handlers_rx.Init.Channel = DMA_CHANNEL_4;
+    dma_handlers_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    dma_handlers_rx.Init.PeriphInc = DMA_PINC_DISABLE;
+    dma_handlers_rx.Init.MemInc = DMA_MINC_ENABLE;
+    dma_handlers_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dma_handlers_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+    dma_handlers_rx.Init.Mode = DMA_CIRCULAR;
+    dma_handlers_rx.Init.Priority = DMA_PRIORITY_LOW;
+    dma_handlers_rx.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
 
-    HAL_DMA_Init(hdma_rx);
+    HAL_DMA_Init(&dma_handlers_rx);
 
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
     /* Associate the initialized DMA handle to the the UART handle */
-    __HAL_LINKDMA(huart, hdmarx, *hdma_rx);
-    dmauart = huart;
+    __HAL_LINKDMA(huart, hdmarx, dma_handlers_rx);
+
     /*##-4- Configure the NVIC for DMA #########################################*/
     /* NVIC configuration for DMA transfer complete interrupt (USART1_RX) */
     HAL_NVIC_SetPriority(DMA2_Stream2_IRQn, 0, 0);
@@ -839,40 +829,37 @@ void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buff
     callback_id_dma_rx = (uint32_t)id;
 }
 
-size_t serial_get_dma_rx_position(serial_t *obj)
+size_t serial_get_dma_rx_position(const serial_t *obj)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
+    const struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     return huart->hdmarx->Instance->NDTR;
 }
 
-void serial_tx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_tx, DmaCompleteCallback callback, uint32_t id)
+void serial_tx_dma_init(serial_t *obj)
 {
     /* USART1_TX Init */
-    hdma_tx->Instance = DMA2_Stream7;
-    hdma_tx->Init.Channel = DMA_CHANNEL_4;
-    hdma_tx->Init.Direction = DMA_MEMORY_TO_PERIPH;
-    hdma_tx->Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_tx->Init.MemInc = DMA_MINC_ENABLE;
-    hdma_tx->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_tx->Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_tx->Init.Mode = DMA_NORMAL;
-    hdma_tx->Init.Priority = DMA_PRIORITY_LOW;
-    hdma_tx->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-    HAL_DMA_Init(hdma_tx);
+    dma_handlers_tx.Instance = DMA2_Stream7;
+    dma_handlers_tx.Init.Channel = DMA_CHANNEL_4;
+    dma_handlers_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+    dma_handlers_tx.Init.PeriphInc = DMA_PINC_DISABLE;
+    dma_handlers_tx.Init.MemInc = DMA_MINC_ENABLE;
+    dma_handlers_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dma_handlers_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+    dma_handlers_tx.Init.Mode = DMA_NORMAL;
+    dma_handlers_tx.Init.Priority = DMA_PRIORITY_LOW;
+    dma_handlers_tx.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
+    HAL_DMA_Init(&dma_handlers_tx);
 
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
-    __HAL_LINKDMA(huart, hdmatx, *hdma_tx);
+    __HAL_LINKDMA(huart, hdmatx, dma_handlers_tx);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
 
     HAL_NVIC_SetPriority(DMA2_Stream7_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(DMA2_Stream7_IRQn);
-
-    callback_dma_tx = callback;
-    callback_id_dma_tx = id;
 }
 
 void serial_rx_dma_free(serial_t *obj)
@@ -891,12 +878,12 @@ void serial_tx_dma_free(serial_t *obj)
     HAL_DMA_DeInit(huart->hdmatx);
 }
 
-size_t serial_tx_dma(serial_t *obj, uint8_t* buffer, size_t buffer_size)
+size_t serial_tx_dma(serial_t *obj, const uint8_t* buffer, size_t buffer_size)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
-    if(HAL_UART_Transmit_DMA(huart, buffer, buffer_size) == HAL_OK) {
+    if(HAL_UART_Transmit_DMA(huart, (uint8_t*)buffer, buffer_size) == HAL_OK) {
         return buffer_size;
     }
     return 0;

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -29,6 +29,8 @@
 
 uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
+DMA_HandleTypeDef dma_handlers_rx;
+DMA_HandleTypeDef dma_handlers_tx;
 
 static uart_irq_handler irq_handler;
 
@@ -641,16 +643,14 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-UART_HandleTypeDef * dmauart;
-
 void DMA1_Channel5_IRQHandler(void)
 {
-    HAL_DMA_IRQHandler(dmauart->hdmarx);
+    HAL_DMA_IRQHandler(&dma_handlers_rx);
 }
 
 void DMA1_Channel4_IRQHandler(void)
 {
-    HAL_DMA_IRQHandler(dmauart->hdmatx);
+    HAL_DMA_IRQHandler(&dma_handlers_tx);
 }
 
 /**
@@ -666,20 +666,10 @@ typedef void(*DmaCompleteCallback)(uint32_t);
 DmaCompleteCallback callback_dma_rx;
 uint32_t callback_id_dma_rx;
 
-DmaCompleteCallback callback_dma_tx;
-uint32_t callback_id_dma_tx;
-
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef* UartHandle)
 {
     /* Set transmission flag: transfer complete*/
     serial_idle_callback();
-}
-
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef* UartHandle)
-{
-    if (callback_dma_tx) {
-        callback_dma_tx(callback_id_dma_tx);
-    }
 }
 
 void serial_idle_callback(void)
@@ -718,27 +708,27 @@ static void uart1_irq_idle(void)
     }
 }
 
-void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buffer, size_t buffer_size, DmaCompleteCallback callback, uint32_t id)
+void serial_rx_dma_init(serial_t *obj, uint8_t* buffer, size_t buffer_size, DmaCompleteCallback callback, uint32_t id)
 {
     __HAL_RCC_DMA1_CLK_ENABLE();
     /* Configure the DMA handler for reception process */
-    hdma_rx->Instance                 = DMA1_Channel5;
-    hdma_rx->Init.Direction           = DMA_PERIPH_TO_MEMORY;
-    hdma_rx->Init.PeriphInc           = DMA_PINC_DISABLE;
-    hdma_rx->Init.MemInc              = DMA_MINC_ENABLE;
-    hdma_rx->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_rx->Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-    hdma_rx->Init.Mode                = DMA_CIRCULAR;
-    hdma_rx->Init.Priority            = DMA_PRIORITY_HIGH;
-    hdma_rx->Init.Request             = DMA_REQUEST_2;
+    dma_handlers_rx.Instance                 = DMA1_Channel5;
+    dma_handlers_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+    dma_handlers_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
+    dma_handlers_rx.Init.MemInc              = DMA_MINC_ENABLE;
+    dma_handlers_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dma_handlers_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+    dma_handlers_rx.Init.Mode                = DMA_CIRCULAR;
+    dma_handlers_rx.Init.Priority            = DMA_PRIORITY_HIGH;
+    dma_handlers_rx.Init.Request             = DMA_REQUEST_2;
 
-    HAL_DMA_Init(hdma_rx);
+    HAL_DMA_Init(&dma_handlers_rx);
 
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
     /* Associate the initialized DMA handle to the the UART handle */
-    __HAL_LINKDMA(huart, hdmarx, *hdma_rx);
-    dmauart = huart;
+    __HAL_LINKDMA(huart, hdmarx, dma_handlers_rx);
+
     /*##-4- Configure the NVIC for DMA #########################################*/
     /* NVIC configuration for DMA transfer complete interrupt (USART1_RX) */
     HAL_NVIC_SetPriority(DMA1_Channel5_IRQn, 0, 0);
@@ -752,8 +742,7 @@ void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buff
     uint32_t vector = (uint32_t)&uart1_irq_idle;
     NVIC_SetVector(USART1_IRQn, vector);
     NVIC_EnableIRQ(USART1_IRQn);
-    if(HAL_UART_Receive_DMA(huart, (uint8_t *)buffer, buffer_size) != HAL_OK)
-    {
+    if(HAL_UART_Receive_DMA(huart, (uint8_t *)buffer, buffer_size) != HAL_OK) {
 
     }
 
@@ -761,39 +750,36 @@ void serial_rx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_rx, uint8_t* buff
     callback_id_dma_rx = (uint32_t)id;
 }
 
-size_t serial_get_dma_rx_position(serial_t *obj)
+size_t serial_get_dma_rx_position(const serial_t *obj)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
+    const struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     return huart->hdmarx->Instance->CNDTR;
 }
 
-void serial_tx_dma_init(serial_t *obj, DMA_HandleTypeDef *hdma_tx, DmaCompleteCallback callback, uint32_t id)
+void serial_tx_dma_init(serial_t *obj)
 {
     /* USART1_TX Init */
-    hdma_tx->Instance = DMA1_Channel4;
-    hdma_tx->Init.Request = DMA_REQUEST_2;
-    hdma_tx->Init.Direction = DMA_MEMORY_TO_PERIPH;
-    hdma_tx->Init.PeriphInc = DMA_PINC_DISABLE;
-    hdma_tx->Init.MemInc = DMA_MINC_ENABLE;
-    hdma_tx->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_tx->Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_tx->Init.Mode = DMA_NORMAL;
-    hdma_tx->Init.Priority = DMA_PRIORITY_LOW;
-    HAL_DMA_Init(hdma_tx);
+    dma_handlers_tx.Instance = DMA1_Channel4;
+    dma_handlers_tx.Init.Request = DMA_REQUEST_2;
+    dma_handlers_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+    dma_handlers_tx.Init.PeriphInc = DMA_PINC_DISABLE;
+    dma_handlers_tx.Init.MemInc = DMA_MINC_ENABLE;
+    dma_handlers_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    dma_handlers_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+    dma_handlers_tx.Init.Mode = DMA_NORMAL;
+    dma_handlers_tx.Init.Priority = DMA_PRIORITY_LOW;
+    HAL_DMA_Init(&dma_handlers_tx);
 
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
-    __HAL_LINKDMA(huart, hdmatx, *hdma_tx);
+    __HAL_LINKDMA(huart, hdmatx, dma_handlers_tx);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
 
     HAL_NVIC_SetPriority(DMA1_Channel4_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(DMA1_Channel4_IRQn);
-
-    callback_dma_tx = callback;
-    callback_id_dma_tx = id;
 }
 
 void serial_rx_dma_free(serial_t *obj)
@@ -812,12 +798,12 @@ void serial_tx_dma_free(serial_t *obj)
     HAL_DMA_DeInit(huart->hdmatx);
 }
 
-size_t serial_tx_dma(serial_t *obj, uint8_t* buffer, size_t buffer_size)
+size_t serial_tx_dma(serial_t *obj, const uint8_t* buffer, size_t buffer_size)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
-    if(HAL_UART_Transmit_DMA(huart, buffer, buffer_size) == HAL_OK) {
+    if(HAL_UART_Transmit_DMA(huart, (uint8_t*)buffer, buffer_size) == HAL_OK) {
         return buffer_size;
     }
     return 0;

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -578,9 +578,9 @@ int serial_readable(serial_t *obj)
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }
 
-int serial_writable(serial_t *obj)
+int serial_writable(const serial_t *obj)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
+    const struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     // Check if data is transmitted


### PR DESCRIPTION
* Moving rx/tx dma struct handles to `TARGET_<family>/serial_device.c`
* Removing the need for tx complete callback.
* Allowed `serial_writeable` to be called from const methods