### PR TITLE
stm32l4 workaround for slow adc on channel 4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
@@ -152,6 +152,7 @@ uint16_t adc_read(analogin_t *obj)
             break;
         case 4:
             sConfig.Channel = ADC_CHANNEL_4;
+            sConfig.SamplingTime = ADC_SAMPLETIME_640CYCLES_5; // Workaround for AIXV-140. For unknown reasons channel 4 is slower.
             break;
         case 5:
             sConfig.Channel = ADC_CHANNEL_5;


### PR DESCRIPTION
The root cause of this is unknown but this change is safe unless fast sampling is required - the sampling time is increased from approx. 0.5 to approx. 8 μs.