### PR TITLE
cortex_m: FaultHandler now always use mbed_fault_handler

### DIFF
--- a/platform/source/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
+++ b/platform/source/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
@@ -103,7 +103,13 @@ UsageFault_Handler:
         .cantunwind
 
 Fault_Handler:
-#if (DOMAIN_NS == 1)
+
+// Always enable FaultHandler for crash diagnostics
+// TrustZone Secure Image: __ARM_FEATURE_CMSE set, DOMAIN_NS=0
+// TrustZone Non-Secure Image: DOMAIN_NS=1
+// Non-TrustZone Image: DOMAIN_NS=0
+// #if (DOMAIN_NS == 1)
+#if 1
 #if MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
 #define mbed_fault_context __CRASH_DATA_RAM_START__
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/nrfx/drivers/src/nrfx_uarte.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/nrfx/drivers/src/nrfx_uarte.c
@@ -457,7 +457,10 @@ nrfx_err_t nrfx_uarte_tx(nrfx_uarte_t const * p_instance,
 
 bool nrfx_uarte_tx_in_progress(nrfx_uarte_t const * p_instance)
 {
-    return (m_cb[p_instance->drv_inst_idx].tx_buffer_length != 0);
+    // note: events also checked to support output when interrupts disabled (e.g. when logging fatal errors)
+    return (m_cb[p_instance->drv_inst_idx].tx_buffer_length != 0 &&
+        !nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_ENDTX) &&
+        !nrf_uarte_event_check(p_instance->p_reg, NRF_UARTE_EVENT_TXSTOPPED));
 }
 
 nrfx_err_t nrfx_uarte_rx(nrfx_uarte_t const * p_instance,


### PR DESCRIPTION
cortex_m: FaultHandler now always use mbed_fault_handler
    
* previously an infinite loop was entered when DOMAIN_NS=0

drivers/nrfx_uarte: support tx when irq disabled, e.g. fatal errors
    
* nrfx_uarte_tx_in_progress now returns false if transmit completed
  even when IRQ handler not have been called yet
