### PR TITLE
NRF5340: Correct ADC channel associated with PinMap

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
@@ -19,38 +19,48 @@
 
 #include "hal/analogin_api.h"
 
-#include "pinmap.h"
 #include "PeripheralPins.h"
 #include "nrfx_saadc.h"
+#include "pinmap.h"
 
 #define ADC_12BIT_RANGE 0x0FFF
 #define ADC_16BIT_RANGE 0xFFFF
 
-static uint8_t channel_index = 0;
-
 #if STATIC_PINMAP_READY
 #define ANALOGIN_INIT_DIRECT analogin_init_direct
-void analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
+void analogin_init_direct(analogin_t* obj, const PinMap* pinmap)
 #else
 #define ANALOGIN_INIT_DIRECT _analogin_init_direct
-static void _analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
+static void _analogin_init_direct(analogin_t* obj, const PinMap* pinmap)
 #endif
 {
-    nrfx_err_t result;
-    static bool first_init = true;
-
     MBED_ASSERT(obj);
     MBED_ASSERT(pinmap->pin != NC);
 
+    nrfx_err_t result = 0;
+
+    /* Only initialize SAADC once */
+    static bool first_init = true;
+
     if (first_init) {
+        first_init = false;
+
         result = nrfx_saadc_init(NRFX_SAADC_DEFAULT_CONFIG_IRQ_PRIORITY);
         MBED_ASSERT(result == NRFX_SUCCESS);
         result = nrfx_saadc_offset_calibrate(NULL);
         MBED_ASSERT(result == NRFX_SUCCESS);
-        first_init = false;
     }
 
-    nrfx_saadc_channel_t channel = NRFX_SAADC_DEFAULT_CHANNEL_SE(pinmap->function, channel_index);
+    /* Use pinmap function to get associated channel.
+     * AIN0 enum val = 1,
+     * AIN0 channel = 0
+     * Subtract the enum offset to get channel index */
+    uint8_t channel_index = pinmap->function - 1;
+    MBED_ASSERT(channel_index != (uint8_t)NC);
+
+    nrfx_saadc_channel_t channel =
+        NRFX_SAADC_DEFAULT_CHANNEL_SE(pinmap->function, channel_index);
+
     /* The 1/4 gain and VDD/4 makes the reference voltage VDD */
     channel.channel_config.gain = NRF_SAADC_GAIN1_4,
     channel.channel_config.reference = NRF_SAADC_REFERENCE_VDD4;
@@ -58,25 +68,29 @@ static void _analogin_init_direct(analogin_t *obj, const PinMap *pinmap)
     result = nrfx_saadc_channel_config(&channel);
     MBED_ASSERT(result == NRFX_SUCCESS);
 
+    /* Store channel in ADC object. */
     obj->channel_index = channel_index;
-    channel_index++;
 }
 
-void analogin_init(analogin_t *obj, PinName pin)
-{
-    const PinMap static_pinmap = {pin, pinmap_peripheral(pin, PinMap_ADC), pinmap_find_function(pin, PinMap_ADC)};
+void analogin_init(analogin_t* obj, PinName pin) {
+    int peripheral = (int)pinmap_peripheral(pin, PinMap_ADC);
+    int function = (int)pinmap_find_function(pin, PinMap_ADC);
+
+    const PinMap static_pinmap = {pin, peripheral, function};
+
     ANALOGIN_INIT_DIRECT(obj, &static_pinmap);
 }
 
-uint16_t analogin_read_u16(analogin_t *obj)
-{
+uint16_t analogin_read_u16(analogin_t* obj) {
     nrfx_err_t result;
     nrf_saadc_value_t value = 0;
 
     MBED_ASSERT(obj);
 
     /* Use simple mode (single sample conversion) in blocking mode */
-    result = nrfx_saadc_simple_mode_set((1 << obj->channel_index), NRF_SAADC_RESOLUTION_12BIT, NRF_SAADC_OVERSAMPLE_DISABLED, NULL);
+    result = nrfx_saadc_simple_mode_set((1 << obj->channel_index),
+                                        NRF_SAADC_RESOLUTION_12BIT,
+                                        NRF_SAADC_OVERSAMPLE_DISABLED, NULL);
     MBED_ASSERT(result == NRFX_SUCCESS);
 
     result = nrfx_saadc_buffer_set(&value, 1);
@@ -89,17 +103,14 @@ uint16_t analogin_read_u16(analogin_t *obj)
     return (((uint32_t)value) * ADC_16BIT_RANGE) / ADC_12BIT_RANGE;
 }
 
-float analogin_read(analogin_t *obj)
-{
+float analogin_read(analogin_t* obj) {
     MBED_ASSERT(obj);
 
-    /* Read 16 bit ADC value (using Mbed API) and convert to [0;1] range float */
+    /* Read 16 bit ADC value (using Mbed API) and convert to [0;1]
+     * range float */
     return ((float)analogin_read_u16(obj) / (float)ADC_16BIT_RANGE);
 }
 
-const PinMap *analogin_pinmap()
-{
-    return PinMap_ADC;
-}
+const PinMap* analogin_pinmap() { return PinMap_ADC; }
 
-#endif // DEVICE_ANALOGIN
+#endif  // DEVICE_ANALOGIN


### PR DESCRIPTION
The ADC channels are supposed to be tied up to their respective PinMap. 
Previously the channel index was randomly selected resulting in a overflow when allocating/deallocating AnalogIn objects.