### PR TITLE
targets/stm32f4xx: I2C_ITError could write to dangling pBuffPtr

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/stm32f4xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/STM32Cube_FW/STM32F4xx_HAL_Driver/stm32f4xx_hal_i2c.c
@@ -4854,12 +4854,8 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c)
 
       if(HAL_DMA_Abort_IT(hi2c->hdmarx) != HAL_OK)
       {
-        /* Store Last receive data if any */
         if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
-        {
-          /* Read data from DR */
-          (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
-        }
+          (void)hi2c->Instance->DR; /* clear I2C_FLAG_RXNE, data discarded */
 
         /* Disable I2C peripheral to prevent dummy data in buffer */
         __HAL_I2C_DISABLE(hi2c);
@@ -4876,12 +4872,8 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c)
     hi2c->State = HAL_I2C_STATE_READY;
     hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
 
-    /* Store Last receive data if any */
     if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
-    {
-      /* Read data from DR */
-      (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
-    }
+      (void)hi2c->Instance->DR; /* clear I2C_FLAG_RXNE, data discarded */
 
     /* Disable I2C peripheral to prevent dummy data in buffer */
     __HAL_I2C_DISABLE(hi2c);
@@ -4891,12 +4883,8 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c)
   }
   else
   {
-    /* Store Last receive data if any */
     if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
-    {
-      /* Read data from DR */
-      (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
-    }
+      (void)hi2c->Instance->DR; /* clear I2C_FLAG_RXNE, data discarded (seen with i2cslave, e.g. after stop in debugger )*/
 
     /* Call user error callback */
     HAL_I2C_ErrorCallback(hi2c);


### PR DESCRIPTION
Discard data from DR when i2c error occurs with RXNE active (to clear IRQ).
Previously appended to whatever pBuffPtr pointed to which could point to memory no longer allocated.
Was fairly easy to reproduce with I2cSlave when resuming after breakpoint.