### PR TITLE
targets/nrf53xx: i2c: implment basic i2c-slave

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -22,11 +22,175 @@
 #include "mbed_error.h"
 #include "nrfx_twim.h"
 
-static bool nrfx_twim_in_use[TWIM_COUNT] = {false};
+#ifdef DEVICE_I2C_ASYNCH
+#define GET_I2C_S(x) &x->i2c
+#else
+#define GET_I2C_S(x) x
+#endif
 
-static void i2c_event_handler(const nrfx_twim_evt_t* event, void* context)
+#if DEVICE_I2CSLAVE
+#include "nrfx_twis.h"
+
+nrfx_err_t twis_buf_req_handler(nrfx_twis_evt_type_t type,
+                                nrfx_twis_t *twis_obj,
+                                i2c_slave_req_buf_cb_t cb,
+                                void *context)
 {
-    i2c_t *obj = (i2c_t *)context;
+    nrfx_err_t err = NRFX_ERROR_NOT_SUPPORTED;
+    uint8_t* buf = NULL;
+    size_t size = 0;
+
+    if (!(twis_obj && cb))
+        return err;
+
+    /* request buffer via callback */
+    cb(context, &buf, &size);
+    if (!buf)
+        return err;
+
+    switch (type) {
+    case NRFX_TWIS_EVT_READ_REQ:
+        err = nrfx_twis_tx_prepare(twis_obj, buf, size);
+        break;
+    case NRFX_TWIS_EVT_WRITE_REQ:
+        err = nrfx_twis_rx_prepare(twis_obj, buf, size);
+        break;
+    default:
+        break;
+    }
+
+    return err;
+}
+
+static struct i2c_s *global_i2c_s = NULL;
+
+void twis_event_handler(nrfx_twis_evt_t const *p_event)
+{
+    bool report_error = false;
+    i2c_slave_error error;
+
+    if (!(global_i2c_s && p_event))
+        return;
+
+    i2c_slave_callbacks *cb_struct = &global_i2c_s->slave_callbacks;
+
+    switch (p_event->type) {
+    case NRFX_TWIS_EVT_READ_REQ:
+        error.code.nrfx = twis_buf_req_handler(p_event->type,
+                                               &global_i2c_s->slave_instance,
+                                               cb_struct->txbuf_req,
+                                               cb_struct->context);
+        report_error = error.code.nrfx != NRFX_SUCCESS;
+        break;
+    case NRFX_TWIS_EVT_WRITE_REQ:
+        error.code.nrfx = twis_buf_req_handler(p_event->type,
+                                               &global_i2c_s->slave_instance,
+                                               cb_struct->rxbuf_req,
+                                               cb_struct->context);
+        report_error = error.code.nrfx != NRFX_SUCCESS;
+        break;
+    case NRFX_TWIS_EVT_READ_DONE:
+        if (cb_struct->tx_done)
+            cb_struct->tx_done(cb_struct->context, p_event->data.rx_amount);
+        break;
+    case NRFX_TWIS_EVT_WRITE_DONE:
+        if (cb_struct->rx_done)
+            cb_struct->rx_done(cb_struct->context, p_event->data.tx_amount);
+        break;
+    case NRFX_TWIS_EVT_READ_ERROR:
+    case NRFX_TWIS_EVT_WRITE_ERROR:
+    case NRFX_TWIS_EVT_GENERAL_ERROR:
+        report_error = true;
+        error.code.twis = p_event->data.error;
+        break;
+    }
+
+    if (report_error && cb_struct->error)
+        cb_struct->error(cb_struct->context, error);
+}
+
+static bool nrfx_twis_in_use[4] = { false };
+
+static nrfx_twis_t get_next_free_twis_instance(void)
+{
+    nrfx_twis_t instance = { .p_reg = NULL, .drv_inst_idx = 0 };
+
+    for (uint8_t index = 0; index < 4; ++index) {
+        if (nrfx_twis_in_use[index])
+            continue;
+
+        switch (index) {
+#if NRFX_CHECK(NRFX_TWIS0_ENABLED)
+        case 0: {
+            nrfx_twis_t instance0 = NRFX_TWIS_INSTANCE(0);
+            instance = instance0;
+            break;
+        }
+#endif
+#if NRFX_CHECK(NRFX_TWIS1_ENABLED)
+        case 1: {
+            nrfx_twis_t instance1 = NRFX_TWIS_INSTANCE(1);
+            instance = instance1;
+            break;
+        }
+#endif
+#if NRFX_CHECK(NRFX_TWIS2_ENABLED)
+        case 2: {
+            nrfx_twis_t instance2 = NRFX_TWIS_INSTANCE(2);
+            instance = instance2;
+            break;
+        }
+#endif
+#if NRFX_CHECK(NRFX_TWIS3_ENABLED)
+        case 3: {
+            nrfx_twis_t instance3 = NRFX_TWIS_INSTANCE(3);
+            instance = instance3;
+            break;
+        }
+#endif
+        default:
+            continue;
+        }
+
+        nrfx_twis_in_use[index] = true;
+        break;
+    }
+
+    return instance;
+}
+
+static bool is_slave_active(i2c_t *obj_)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+    return obj->slave_instance.p_reg && obj->slave_instance.p_reg->ENABLE;
+}
+
+static void deinit_slave(i2c_t *obj_)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+    if (!obj->slave_instance.p_reg)
+        return;
+
+    nrfx_twis_disable(&obj->slave_instance);
+    nrfx_twis_uninit(&obj->slave_instance);
+    nrfx_twis_in_use[obj->slave_instance.drv_inst_idx] = false;
+}
+
+#endif // DEVICE_I2CSLAVE
+
+static bool nrfx_twim_in_use[TWIM_COUNT] = { false };
+
+static bool is_master_active(i2c_t *obj_)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+    return obj->instance.p_twim && obj->instance.p_twim->ENABLE;
+}
+
+static void i2c_event_handler(const nrfx_twim_evt_t *event, void *context)
+{
+    i2c_t *obj_ = (i2c_t *)context;
+    struct i2c_s* obj = GET_I2C_S(obj_);
+
     if (obj) {
         switch (event->type) {
             case NRFX_TWIM_EVT_DONE:
@@ -46,11 +210,25 @@ static void i2c_event_handler(const nrfx_twim_evt_t* event, void* context)
     }
 }
 
-void i2c_init(i2c_t *obj, PinName sda, PinName scl)
+static void deinit_master(i2c_t *obj_)
 {
+    struct i2c_s *obj = GET_I2C_S(obj_);
+    if (!obj->instance.p_twim)
+        return;
+
+    nrfx_twim_disable(&obj->instance);
+    nrfx_twim_uninit(&obj->instance);
+    nrfx_twim_in_use[obj->instance.drv_inst_idx] = false;
+}
+
+void i2c_init(i2c_t *obj_, PinName sda, PinName scl)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
     MBED_ASSERT(obj);
     memset(obj, 0, sizeof(*obj));
     obj->instance.drv_inst_idx = NRFX_TWIM_ENABLED_COUNT;
+    obj->instance.p_twim = NULL;
 
     for (uint8_t index = 0; index < TWIM_COUNT; ++index) {
         if (!nrfx_twim_in_use[index]) {
@@ -92,15 +270,34 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     }
     MBED_ASSERT(obj->instance.drv_inst_idx < NRFX_UARTE_ENABLED_COUNT);
 
+#if DEVICE_I2CSLAVE
+    obj->is_slave = false;
+    obj->slave_addr = 0;
+    obj->slave_instance.p_reg = NULL;
+    obj->slave_callbacks.rxbuf_req = NULL;
+    obj->slave_callbacks.txbuf_req = NULL;
+    obj->slave_callbacks.rx_done = NULL;
+    obj->slave_callbacks.tx_done = NULL;
+    obj->slave_callbacks.error = NULL;
+#endif // DEVICE_I2CSLAVE
+
     nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl, sda);
     memcpy(&obj->config, &config, sizeof(obj->config));
-    nrfx_twim_init(&obj->instance, &obj->config, i2c_event_handler, obj);
-    nrfx_twim_enable(&obj->instance);
 }
 
-void i2c_frequency(i2c_t *obj, int hz)
+void i2c_frequency(i2c_t *obj_, int hz)
 {
-    nrfx_twim_uninit(&obj->instance);
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+#if DEVICE_I2CSLAVE
+    /* master instance invalid -> device is slave -> freq can't be configured */
+    if (!obj->instance.p_twim)
+        return;
+#endif
+
+    /* master will re-init on next use */
+    if (is_master_active(obj_))
+        deinit_master(obj_);
 
     switch (hz) {
         case 100000:
@@ -121,20 +318,75 @@ void i2c_frequency(i2c_t *obj, int hz)
             MBED_WARNING1(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SERIAL, MBED_ERROR_CODE_UNSUPPORTED), "frequency not supported", hz);
             break;
     }
-
-    nrfx_twim_init(&obj->instance, &obj->config, i2c_event_handler, obj);
-    nrfx_twim_enable(&obj->instance);
 }
 
-int i2c_start(i2c_t *obj)
+/**
+ * @brief      Reconfigure driver.
+ *
+ *             If the peripheral is enabled, it will be disabled first. All
+ *             registers are cleared to their default values unless replaced
+ *             by new configuration.
+ *
+ * @param      obj           The object
+ */
+static void i2c_configure_driver_instance(i2c_t *obj_)
 {
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* If the peripheral is running, disable and uninitialize it.*/
+    if (is_master_active(obj_))
+        deinit_master(obj_);
+
+#if DEVICE_I2CSLAVE
+    if (is_slave_active(obj_))
+        deinit_slave(obj_);
+
+    /* Configure slave driver if device is slave */
+    if (obj->is_slave) {
+        nrfx_twis_config_t twis_config =
+            NRFX_TWIS_DEFAULT_CONFIG(obj->config.scl, obj->config.sda,
+                                     obj->slave_addr >> 1);
+
+        /* FIXME: add error handling */
+        nrfx_twis_init(&obj->slave_instance, &twis_config, twis_event_handler);
+        nrfx_twis_enable(&obj->slave_instance);
+        nrfx_twis_in_use[obj->slave_instance.drv_inst_idx] = true;
+
+        /* FIXME: use array of i2c_s ptr instead? */
+        global_i2c_s = obj;
+        return;
+    }
+#endif // DEVICE_I2CSLAVE
+
+    /* Configure driver as master if device is master */
+    if (obj->instance.p_twim) {
+        nrfx_twim_init(&obj->instance, &obj->config, i2c_event_handler, obj_);
+        nrfx_twim_enable(&obj->instance);
+        nrfx_twim_in_use[obj->instance.drv_inst_idx] = true;
+    }
+}
+
+int i2c_start(i2c_t *obj_)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
     obj->length = 0;
     obj->address = 0;
+
     return 0;
 }
 
-int i2c_byte_write(i2c_t *obj, int data)
+int i2c_byte_write(i2c_t *obj_, int data)
 {
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if master instance is invalid */
+    if (!obj->instance.p_twim)
+        return 0;
+
+    if (!is_master_active(obj_))
+        i2c_configure_driver_instance(obj_);
+
     /* The TWIM driver does not support single byte writes so combine the bytes and send on i2c_stop() */
     if (obj->address == 0) {
         obj->address = data;
@@ -152,10 +404,12 @@ int i2c_byte_read(i2c_t *obj, int last)
     return I2C_ERROR_NO_SLAVE;
 }
 
-int i2c_stop(i2c_t *obj)
+int i2c_stop(i2c_t *obj_)
 {
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
     if (obj->length) {
-        i2c_write(obj, obj->address, &obj->buffer[0], obj->length, true);
+        i2c_write(obj_, obj->address, &obj->buffer[0], obj->length, true);
     }
 
     return 0;
@@ -163,14 +417,26 @@ int i2c_stop(i2c_t *obj)
 
 void i2c_reset(i2c_t *obj)
 {
-    uint8_t index = obj->instance.drv_inst_idx;
-    nrfx_twim_uninit(&obj->instance);
-    nrfx_twim_in_use[index] = false;
+    if (is_master_active(obj))
+        deinit_master(obj);
+#if DEVICE_I2CSLAVE
+    if (is_slave_active(obj))
+        deinit_slave(obj);
+#endif // DEVICE_I2CSLAVE
 }
 
-int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
+int i2c_read(i2c_t *obj_, int address, char *data, int length, int stop)
 {
-    while(nrfx_twim_is_busy(&obj->instance));
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if master instance is invalid */
+    if (!obj->instance.p_twim)
+        return 0;
+
+    if (!is_master_active(obj_))
+        i2c_configure_driver_instance(obj_);
+
+    while (nrfx_twim_is_busy(&obj->instance));
 
     obj->transfer_complete = false;
     nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_RX(address >> 1, (uint8_t *)data, length);
@@ -182,9 +448,18 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     return obj->transfer_result;
 }
 
-int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
+int i2c_write(i2c_t *obj_, int address, const char *data, int length, int stop)
 {
-    while(nrfx_twim_is_busy(&obj->instance));
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if master instance is invalid */
+    if (!obj->instance.p_twim)
+        return 0;
+
+    if (!is_master_active(obj_))
+        i2c_configure_driver_instance(obj_);
+
+    while (nrfx_twim_is_busy(&obj->instance));
 
     obj->transfer_complete = false;
     nrfx_twim_xfer_desc_t descriptor = NRFX_TWIM_XFER_DESC_TX(address >> 1, (uint8_t *)data, length);
@@ -195,5 +470,124 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     while(!obj->transfer_complete);
     return obj->transfer_result;
 }
+
+#if DEVICE_I2CSLAVE
+
+/** Configure I2C as slave or master.
+ *  @param obj_ The I2C object
+ *  @param enable_slave Enable i2c hardware in slave mode
+ *  @return non-zero if a value is available
+ */
+void i2c_slave_mode(i2c_t *obj_, int enable_slave)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* Reconfigure this instance as an I2C slave */
+    obj->is_slave = enable_slave;
+
+    if (obj->is_slave && !obj->slave_instance.p_reg) {
+        obj->slave_instance = get_next_free_twis_instance();
+    }
+
+    i2c_configure_driver_instance(obj_);
+}
+
+/** Check to see if the I2C slave has been addressed.
+ *  @param obj The I2C object
+ *  @return The status - 1 - read addresses, 2 - write to all slaves,
+ *         3 write addressed, 0 - the slave has not been addressed
+ */
+int i2c_slave_receive(i2c_t *obj_)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if slave instance is invalid */
+    if (!obj->slave_instance.p_reg)
+        return 0;
+
+    if (nrfx_twis_is_waiting_rx_buff(&obj->slave_instance)) {
+        return 3;
+    }
+
+    if (nrfx_twis_is_waiting_tx_buff(&obj->slave_instance)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/** Configure I2C as slave or master.
+ *  @param obj The I2C object
+ *  @param data    The buffer for receiving
+ *  @param length  Number of bytes to read
+ *  @return non-zero if a value is available
+ */
+int i2c_slave_read(i2c_t *obj_, char *data, int length)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if slave instance is invalid */
+    if (!obj->slave_instance.p_reg)
+        return 0;
+
+    const nrfx_twis_t *twis_instance = &obj->slave_instance;
+
+    /* Wait until the master is trying to write data */
+    while (!nrfx_twis_is_waiting_rx_buff(twis_instance)) { }
+
+    /* Master is attempting to write, now we prepare the rx buffer */
+    nrfx_twis_rx_prepare(twis_instance, data, length);
+
+    /* Wait until the transaction is over */
+    while (nrfx_twis_is_pending_rx(twis_instance)) { }
+
+    return nrfx_twis_rx_amount(twis_instance);
+}
+
+/** Configure I2C as slave or master.
+ *  @param obj The I2C object
+ *  @param data    The buffer for sending
+ *  @param length  Number of bytes to write
+ *  @return non-zero if a value is available
+ */
+int i2c_slave_write(i2c_t *obj_, const char* data, int length)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* return if slave instance is invalid */
+    if (!obj->slave_instance.p_reg)
+        return 0;
+
+    const nrfx_twis_t *twis_instance = &obj->slave_instance;
+
+    /* Wait until the master is trying to read data */
+    while (!nrfx_twis_is_waiting_tx_buff(twis_instance)) { }
+
+    /* Master is attempting to read, now we prepare the tx buffer */
+    nrfx_twis_tx_prepare(twis_instance, data, length);
+
+    /* Wait until the transaction is over */
+    while (nrfx_twis_is_pending_tx(twis_instance)) { }
+
+    return nrfx_twis_tx_amount(twis_instance);
+}
+
+/** Configure I2C address.
+ *  @param obj     The I2C object
+ *  @param idx     Currently not used
+ *  @param address The address to be set
+ *  @param mask    Currently not used
+ */
+void i2c_slave_address(i2c_t *obj_, int idx, uint32_t address, uint32_t mask)
+{
+    struct i2c_s *obj = GET_I2C_S(obj_);
+
+    /* Reconfigure this instance as an I2C slave with given address */
+    obj->slave_addr = (uint8_t)address;
+
+    i2c_configure_driver_instance(obj_);
+}
+
+#endif // DEVICE_I2CSLAVE
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -514,6 +514,7 @@ void i2c_slave_mode(i2c_t *obj_, int enable_slave)
  */
 int i2c_slave_receive(i2c_t *obj_)
 {
+    /* At the time of implementing, the blocking interface is untested */
     struct i2c_s *obj = GET_I2C_S(obj_);
 
     /* return if slave instance is invalid */
@@ -539,6 +540,7 @@ int i2c_slave_receive(i2c_t *obj_)
  */
 int i2c_slave_read(i2c_t *obj_, char *data, int length)
 {
+    /* At the time of implementing, the blocking interface is untested */
     struct i2c_s *obj = GET_I2C_S(obj_);
 
     /* return if slave instance is invalid */
@@ -567,6 +569,7 @@ int i2c_slave_read(i2c_t *obj_, char *data, int length)
  */
 int i2c_slave_write(i2c_t *obj_, const char* data, int length)
 {
+    /* At the time of implementing, the blocking interface is untested */
     struct i2c_s *obj = GET_I2C_S(obj_);
 
     /* return if slave instance is invalid */

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -31,11 +31,19 @@
 #if DEVICE_I2CSLAVE
 #include "nrfx_twis.h"
 
-#if (NRFX_TWIS_ENABLED_COUNT < 1)
+/* nrfx_twis.h does not define this for twis, only twim */
+#ifndef TWIS_COUNT
+#define TWIS_COUNT 4
+#endif
+
+#if !(NRFX_TWIS0_ENABLED    \
+    || NRFX_TWIS1_ENABLED   \
+    || NRFX_TWIS2_ENABLED   \
+    || NRFX_TWIS3_ENABLED)
 #error "Cannot use DEVICE_I2CSLAVE without any TWIS enabled"
 #endif
 
-static bool nrfx_twis_in_use[NRFX_TWIS_ENABLED_COUNT] = { false };
+static bool nrfx_twis_in_use[TWIS_COUNT] = { false };
 static struct i2c_s *global_i2c_s = NULL;
 
 static nrfx_err_t twis_buf_req_handler(nrfx_twis_evt_type_t type,
@@ -118,7 +126,7 @@ static nrfx_twis_t get_next_free_twis_instance(void)
 {
     nrfx_twis_t instance = { .p_reg = NULL, .drv_inst_idx = 0 };
 
-    for (uint8_t index = 0; index < NRFX_TWIS_ENABLED_COUNT; ++index) {
+    for (uint8_t index = 0; index < TWIS_COUNT; ++index) {
         if (nrfx_twis_in_use[index])
             continue;
 
@@ -286,6 +294,10 @@ void i2c_init(i2c_t *obj_, PinName sda, PinName scl)
 
     nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl, sda);
     memcpy(&obj->config, &config, sizeof(obj->config));
+
+    /* Defer init of the underlying driver instance until first usage to allow
+     * changing to slave mode before attempting to init a master instance
+     * */
 }
 
 void i2c_frequency(i2c_t *obj_, int hz)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/i2c_api.c
@@ -31,7 +31,14 @@
 #if DEVICE_I2CSLAVE
 #include "nrfx_twis.h"
 
-nrfx_err_t twis_buf_req_handler(nrfx_twis_evt_type_t type,
+#if (NRFX_TWIS_ENABLED_COUNT < 1)
+#error "Cannot use DEVICE_I2CSLAVE without any TWIS enabled"
+#endif
+
+static bool nrfx_twis_in_use[NRFX_TWIS_ENABLED_COUNT] = { false };
+static struct i2c_s *global_i2c_s = NULL;
+
+static nrfx_err_t twis_buf_req_handler(nrfx_twis_evt_type_t type,
                                 nrfx_twis_t *twis_obj,
                                 i2c_slave_req_buf_cb_t cb,
                                 void *context)
@@ -62,9 +69,7 @@ nrfx_err_t twis_buf_req_handler(nrfx_twis_evt_type_t type,
     return err;
 }
 
-static struct i2c_s *global_i2c_s = NULL;
-
-void twis_event_handler(nrfx_twis_evt_t const *p_event)
+static void twis_event_handler(nrfx_twis_evt_t const *p_event)
 {
     bool report_error = false;
     i2c_slave_error error;
@@ -109,13 +114,11 @@ void twis_event_handler(nrfx_twis_evt_t const *p_event)
         cb_struct->error(cb_struct->context, error);
 }
 
-static bool nrfx_twis_in_use[4] = { false };
-
 static nrfx_twis_t get_next_free_twis_instance(void)
 {
     nrfx_twis_t instance = { .p_reg = NULL, .drv_inst_idx = 0 };
 
-    for (uint8_t index = 0; index < 4; ++index) {
+    for (uint8_t index = 0; index < NRFX_TWIS_ENABLED_COUNT; ++index) {
         if (nrfx_twis_in_use[index])
             continue;
 
@@ -382,7 +385,7 @@ int i2c_byte_write(i2c_t *obj_, int data)
 
     /* return if master instance is invalid */
     if (!obj->instance.p_twim)
-        return 0;
+        return I2C_ERROR_NO_SLAVE;
 
     if (!is_master_active(obj_))
         i2c_configure_driver_instance(obj_);
@@ -431,7 +434,7 @@ int i2c_read(i2c_t *obj_, int address, char *data, int length, int stop)
 
     /* return if master instance is invalid */
     if (!obj->instance.p_twim)
-        return 0;
+        return I2C_ERROR_NO_SLAVE;
 
     if (!is_master_active(obj_))
         i2c_configure_driver_instance(obj_);
@@ -503,7 +506,7 @@ int i2c_slave_receive(i2c_t *obj_)
 
     /* return if slave instance is invalid */
     if (!obj->slave_instance.p_reg)
-        return 0;
+        return I2C_ERROR_NO_SLAVE;
 
     if (nrfx_twis_is_waiting_rx_buff(&obj->slave_instance)) {
         return 3;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/objects.h
@@ -49,6 +49,9 @@
 #include "nrfx_spi.h"
 #endif
 #include "nrfx_twim.h"
+#if DEVICE_I2CSLAVE
+#include "nrfx_twis.h"
+#endif
 
 #include "nrf_pwm.h"
 
@@ -109,6 +112,29 @@ struct pwmout_s {
     nrf_pwm_sequence_t sequence;
 };
 
+#if DEVICE_I2CSLAVE
+typedef struct {
+    nrfx_twis_evt_type_t event;
+    union {
+        nrfx_twis_error_t twis;
+        nrfx_err_t nrfx;
+    } code;
+} i2c_slave_error;
+
+typedef void (*i2c_slave_req_buf_cb_t)(void *, uint8_t **, size_t *);
+typedef void (*i2c_slave_xfer_done_cb_t)(void *, size_t);
+typedef void (*i2c_slave_error_cb_t)(void *, i2c_slave_error);
+
+typedef struct {
+    void *context;
+    i2c_slave_req_buf_cb_t rxbuf_req;
+    i2c_slave_req_buf_cb_t txbuf_req;
+    i2c_slave_xfer_done_cb_t rx_done;
+    i2c_slave_xfer_done_cb_t tx_done;
+    i2c_slave_error_cb_t error;
+} i2c_slave_callbacks;
+#endif // DEVICE_I2CSLAVE
+
 struct i2c_s {
     nrfx_twim_t instance;
     nrfx_twim_config_t config;
@@ -117,6 +143,13 @@ struct i2c_s {
     int address;
     char buffer[256];
     uint16_t length;
+
+#if DEVICE_I2CSLAVE
+    bool is_slave;
+    uint8_t slave_addr;
+    nrfx_twis_t slave_instance;
+    i2c_slave_callbacks slave_callbacks;
+#endif // DEVICE_I2CSLAVE
 };
 
 struct analogin_s {


### PR DESCRIPTION
This commit adds a basic I2C slave implementation based on the NRFX TWIS
driver. This implementation is heavily inspired by the one from nrf52xx.
There are some major differences though, as the I2C master role uses
TWIM for nrf53xx and TWI directly for nrf52xx.

Additionally this commit slightly changes the I2C master implementation
to initialize the TWIM driver when a [read,write] happens and the device
is not already running. Previously it would always initialize the TWIM
device immediately, leaving no time to configure the device as a slave
role. The deferred master init is also present in the current
implementation for nrf52xx and I haven't seen any issues with it.

Interfacing with the I2C slave has some rough edges. The user has to
reach into the internal structure of the i2c configuration to assign
callbacks. We should consider extending the MBED i2c_slave API in the
future. To assign callbacks and a client context, the
`i2c_slave_callbacks` struct should be configured within the i2c_s
structure.

Currently the implementation forces async mode using EasyDMA (forced by
the NRFX TWIS driver) which puts a requirement on buffers passed to the
i2c slave to be allocated in the `data` region of the memory.
The synchrounous calls to i2c_slave_[read,write] haven't been tested,
but they are copied from the nrf52xx implementation.

Another limitation of the implementation is that you may only use a
single I2C slave device due to the single global i2c_s pointer design.
Implementing more flexibility is definitely relevant, but is not that
straight forward to do since the TWIS driver API doesn't contain any
context passing.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
