### PR TITLE
Revert "HACK: Fix malloc lock caused by WEAK property"

### DIFF
--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -1642,10 +1642,10 @@ extern "C" WEAK void *__aeabi_read_tp(void)
 #elif defined (__GNUC__)
 struct _reent;
 // Stub out locks when an rtos is not present
-extern "C" WEAK void __rtos_malloc_lock(struct _reent *_r);
-extern "C" WEAK void __rtos_malloc_unlock(struct _reent *_r);
-extern "C" WEAK void __rtos_env_lock(struct _reent *_r);
-extern "C" WEAK void __rtos_env_unlock(struct _reent *_r);
+extern "C" WEAK void __rtos_malloc_lock(struct _reent *_r) {}
+extern "C" WEAK void __rtos_malloc_unlock(struct _reent *_r) {}
+extern "C" WEAK void __rtos_env_lock(struct _reent *_r) {}
+extern "C" WEAK void __rtos_env_unlock(struct _reent *_r) {}
 
 extern "C" void __malloc_lock(struct _reent *_r)
 {


### PR DESCRIPTION
This reverts commit b6b04c6202b1d40efb6535edc03691be1ab92f87.

Root cause has been found (thanks to @GuillermoOlivera :1st_place_medal:).

GCC bugs have been reported in the past related to this issue:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83967
- https://bugs.launchpad.net/gcc-arm-embedded/+bug/1747966