### PR TITLE
nrf53xx: analogin: prevent errornous conversion

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF53/analogin_api.c
@@ -99,6 +99,10 @@ uint16_t analogin_read_u16(analogin_t* obj) {
     result = nrfx_saadc_mode_trigger();
     MBED_ASSERT(result == NRFX_SUCCESS);
 
+    /* clamp value positive to prevent the following conversion from erroring */
+    if (value < 0)
+        value = 0;
+
     /* Convert the value from 12 to 16-bit as used by Mbed */
     return (((uint32_t)value) * ADC_16BIT_RANGE) / ADC_12BIT_RANGE;
 }


### PR DESCRIPTION
Debugging some unexplainably high voltage readouts in a real world application, it was discovered that the nrf5340 ADC can (and will) return negative values.
Occasionally, these would cause the conversion with lots of casting to fail and the result would underflow.

This is a simple workaround for the problem. Since the function is supposed to return a uint16_t it doesn't seem like an issue to clamp the ADC reading positive to me.
It is clear that any applications relying on the `analogin_read_u16` functionality must've worked with strictly positive ADC measurements as otherwise, the applications would have been unreliable and return incorrect measurements anyway.