### PR TITLE
equeue: fix memory corruption issue caused by generation clash

### DIFF
--- a/events/include/events/equeue.h
+++ b/events/include/events/equeue.h
@@ -61,8 +61,9 @@ struct equeue_event {
 typedef struct equeue {
     struct equeue_event *queue;
     unsigned tick;
+
+    uint16_t generation;
     bool break_requested;
-    uint8_t generation;
 
     unsigned char *buffer;
     unsigned npw2;

--- a/events/include/events/equeue.h
+++ b/events/include/events/equeue.h
@@ -42,8 +42,8 @@ extern "C" {
 // Internal event structure
 struct equeue_event {
     unsigned size;
+    uint16_t generation;
     uint8_t id;
-    uint8_t generation;
 
     struct equeue_event *next;
     struct equeue_event *sibling;

--- a/events/source/equeue.c
+++ b/events/source/equeue.c
@@ -351,8 +351,8 @@ static struct equeue_event *equeue_dequeue(equeue_t *q, unsigned target)
 {
     equeue_mutex_lock(&q->queuelock);
 
-    // find all expired events and mark a new generation
-    q->generation += 1;
+    // find all expired events
+
     if (equeue_tickdiff(q->tick, target) <= 0) {
         q->tick = target;
     }
@@ -369,6 +369,12 @@ static struct equeue_event *equeue_dequeue(equeue_t *q, unsigned target)
     }
 
     *p = 0;
+
+    /* we only increment the generation if events have been taken off the queue
+     * as this is the only time cancellation may conflict with dequeueing */
+    if (head) {
+        q->generation += 1;
+    }
 
     equeue_mutex_unlock(&q->queuelock);
 


### PR DESCRIPTION
Cherry-picked from upstream.

More info about the issue can be found here: https://github.com/ARMmbed/mbed-os/pull/14405
